### PR TITLE
Rename transaction column to transaction_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ That's it! Your application is now tracking all creates, updates, and deletes.
 
 ### Audit Log Viewer
 Browse and search audit logs through a built-in web interface at `/admin/audit-logs`:
-- Filter by table, user, event type, date range, transaction ID
+- Filter by table, user, event type, date range, transaction key
 - View detailed before/after comparisons with inline or side-by-side diff
 - Timeline view showing complete history for specific records
 - Export to CSV or JSON

--- a/config/Migrations/20171018185609_CreateAuditLogs.php
+++ b/config/Migrations/20171018185609_CreateAuditLogs.php
@@ -22,7 +22,7 @@ class CreateAuditLogs extends BaseMigration
                 'signed' => false,
             ])
             ->addPrimaryKey(['id'])
-            ->addColumn('transaction', 'binaryuuid', [
+            ->addColumn('transaction_key', 'binaryuuid', [
                 'default' => null,
                 'limit' => null,
                 'null' => false,
@@ -78,7 +78,7 @@ class CreateAuditLogs extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addIndex(['transaction'])
+            ->addIndex(['transaction_key'])
             ->addIndex(['type'])
             ->addIndex(['primary_key'])
             ->addIndex(['display_value'])

--- a/config/Migrations/20260416120000_RenameTransactionToTransactionKey.php
+++ b/config/Migrations/20260416120000_RenameTransactionToTransactionKey.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+class RenameTransactionToTransactionKey extends BaseMigration
+{
+    public function up(): void
+    {
+        $this->table('audit_logs')
+            ->renameColumn('transaction', 'transaction_key')
+            ->update();
+    }
+
+    public function down(): void
+    {
+        $this->table('audit_logs')
+            ->renameColumn('transaction_key', 'transaction')
+            ->update();
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ Optionally, bake the corresponding table class if you need to customize it:
 bin/cake bake model AuditLogs
 ```
 
-**Performance Note:** The migration uses `binaryuuid` for the transaction field, which stores UUIDs as BINARY(16) instead of CHAR(36).
+**Performance Note:** The migration uses `binaryuuid` for the transaction_key field, which stores UUIDs as BINARY(16) instead of CHAR(36).
 This provides ~56% space savings and better index performance.
 
 ### Native JSON Columns

--- a/docs/gdpr.md
+++ b/docs/gdpr.md
@@ -115,7 +115,7 @@ Export format:
   "audit_logs": [
     {
       "id": 1234,
-      "transaction": "abc-123-def",
+      "transaction_key": "abc-123-def",
       "type": "update",
       "source": "Articles",
       "primary_key": "42",

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -134,7 +134,7 @@ Posts alert data to an external URL as JSON.
         "type": "delete",
         "source": "users",
         "primary_key": 456,
-        "transaction": "550e8400-e29b-41d4-a716-446655440000",
+        "transaction_key": "550e8400-e29b-41d4-a716-446655440000",
         "created": "2024-03-15T14:30:00+00:00"
     },
     "context": {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -153,7 +153,7 @@ The following audit events will be created:
 2. **ArticlesTags** - For each new tag association (create event)
 3. **ArticlesTags** - For each removed tag association (delete event, if using `replace` strategy)
 
-All events in a single save operation share the same `transaction` ID, making it easy to see all related changes.
+All events in a single save operation share the same `transaction_key` ID, making it easy to see all related changes.
 
 ### Logging Cascade-Deleted Records
 
@@ -640,7 +640,7 @@ class MyPersister implements PersisterInterface
             $eventType = $log->getEventType();
             $data = [
                 'timestamp' => $log->getTimestamp(),
-                'transaction' => $log->getTransactionId(),
+                'transaction_key' => $log->getTransactionId(),
                 'type' => $log->getEventType(),
                 'primary_key' => $log->getId(),
                 'source' => $log->getSourceName(),

--- a/docs/viewer.md
+++ b/docs/viewer.md
@@ -256,7 +256,7 @@ The `formatRecord()` helper method is used in the built-in audit log templates. 
 
 The audit log viewer provides:
 
-- **Browse & Search**: Filter audit logs by table, user, event type, transaction ID, date range, and primary key
+- **Browse & Search**: Filter audit logs by table, user, event type, transaction key, date range, and primary key
 - **Detailed View**: View full details of any audit log entry with before/after comparison
 - **Timeline View**: See the complete history of changes for a specific record in chronological order
 - **Diff Display**: Human-readable before/after comparison with two display modes:

--- a/src/Action/ElasticLogsIndexAction.php
+++ b/src/Action/ElasticLogsIndexAction.php
@@ -48,8 +48,8 @@ class ElasticLogsIndexAction extends IndexAction
             $query->where(['primary_key' => $request->getQuery('primary_key')]);
         }
 
-        if ($request->getQuery('transaction')) {
-            $query->where(['transaction' => $request->getQuery('transaction')]);
+        if ($request->getQuery('transaction_key')) {
+            $query->where(['transaction_key' => $request->getQuery('transaction_key')]);
         }
 
         if ($request->getQuery('user')) {

--- a/src/Command/ElasticImportCommand.php
+++ b/src/Command/ElasticImportCommand.php
@@ -245,7 +245,7 @@ class ElasticImportCommand extends Command
     {
         $data = [
             '@timestamp' => $audit['created'],
-            'transaction' => $audit['id'],
+            'transaction_key' => $audit['id'],
             'type' => $audit['event'] === 'EDIT' ? 'update' : strtolower($audit['event']),
             'primary_key' => $audit['entity_id'],
             'original' => $audit['original'],

--- a/src/Controller/Admin/AuditLogsController.php
+++ b/src/Controller/Admin/AuditLogsController.php
@@ -79,8 +79,8 @@ class AuditLogsController extends AppController
         }
 
         // Filter by transaction ID
-        if ($this->request->getQuery('transaction')) {
-            $query->where(['AuditLogs.transaction' => $this->request->getQuery('transaction')]);
+        if ($this->request->getQuery('transaction_key')) {
+            $query->where(['AuditLogs.transaction_key' => $this->request->getQuery('transaction_key')]);
         }
 
         // Filter by primary key
@@ -167,8 +167,8 @@ class AuditLogsController extends AppController
         if ($this->request->getQuery('type')) {
             $query->where(['AuditLogs.type' => $this->request->getQuery('type')]);
         }
-        if ($this->request->getQuery('transaction')) {
-            $query->where(['AuditLogs.transaction' => $this->request->getQuery('transaction')]);
+        if ($this->request->getQuery('transaction_key')) {
+            $query->where(['AuditLogs.transaction_key' => $this->request->getQuery('transaction_key')]);
         }
         if ($this->request->getQuery('primary_key')) {
             $query->where(['AuditLogs.primary_key' => $this->request->getQuery('primary_key')]);
@@ -378,10 +378,10 @@ class AuditLogsController extends AppController
         // Group by transaction
         $transactions = [];
         foreach ($auditLogs as $log) {
-            $transactionId = $log->transaction;
+            $transactionId = $log->transaction_key;
             if (!isset($transactions[$transactionId])) {
                 $transactions[$transactionId] = [
-                    'transaction' => $transactionId,
+                    'transaction_key' => $transactionId,
                     'created' => $log->created,
                     'user_id' => $log->user_id,
                     'user_display' => $log->user_display,
@@ -489,7 +489,7 @@ class AuditLogsController extends AppController
         foreach ($auditLogs as $log) {
             fputcsv($output, [
                 $log->id,
-                $log->transaction,
+                $log->transaction_key,
                 $log->type->value,
                 $log->source,
                 $log->primary_key,
@@ -531,7 +531,7 @@ class AuditLogsController extends AppController
         foreach ($auditLogs as $log) {
             $data[] = [
                 'id' => $log->id,
-                'transaction' => $log->transaction,
+                'transaction_key' => $log->transaction_key,
                 'type' => $log->type->value,
                 'source' => $log->source,
                 'primary_key' => $log->primary_key,

--- a/src/Event/SerializableEventTrait.php
+++ b/src/Event/SerializableEventTrait.php
@@ -68,7 +68,7 @@ trait SerializableEventTrait
     {
         return [
             'type' => $this->getEventType(),
-            'transaction' => $this->transactionId,
+            'transaction_key' => $this->transactionId,
             'primary_key' => $this->id,
             'source' => $this->source,
             'parent_source' => $this->parentSource,

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -32,7 +32,7 @@ class EventFactory
             $parentSource = $data['parent_source'] ?? null;
             $original = array_key_exists('original', $data) ? $data['original'] : [];
             $event = new AuditDeleteEvent(
-                $data['transaction'],
+                $data['transaction_key'],
                 $data['primary_key'],
                 $data['source'],
                 $parentSource,
@@ -41,7 +41,7 @@ class EventFactory
             );
         } elseif ($data['type'] === 'create') {
             $event = new AuditCreateEvent(
-                $data['transaction'],
+                $data['transaction_key'],
                 $data['primary_key'],
                 $data['source'],
                 array_key_exists('changed', $data) ? $data['changed'] : [],
@@ -51,7 +51,7 @@ class EventFactory
             );
         } else {
             $event = new AuditUpdateEvent(
-                $data['transaction'],
+                $data['transaction_key'],
                 $data['primary_key'],
                 $data['source'],
                 array_key_exists('changed', $data) ? $data['changed'] : [],

--- a/src/Model/Entity/AuditLog.php
+++ b/src/Model/Entity/AuditLog.php
@@ -10,7 +10,7 @@ use Cake\ORM\Entity;
  * AuditLog Entity
  *
  * @property int $id
- * @property string $transaction
+ * @property string $transaction_key
  * @property \AuditStash\AuditLogType $type
  * @property int|string|null $primary_key
  * @property string|null $display_value
@@ -31,7 +31,7 @@ class AuditLog extends Entity
      * @var array<string, bool>
      */
     protected array $_accessible = [
-        'transaction' => true,
+        'transaction_key' => true,
         'type' => true,
         'primary_key' => true,
         'display_value' => true,

--- a/src/Model/Table/AuditLogsTable.php
+++ b/src/Model/Table/AuditLogsTable.php
@@ -77,10 +77,10 @@ class AuditLogsTable extends Table
             ->allowEmptyString('id', null, 'create');
 
         $validator
-            ->scalar('transaction')
-            ->maxLength('transaction', 36)
-            ->requirePresence('transaction', 'create')
-            ->notEmptyString('transaction');
+            ->scalar('transaction_key')
+            ->maxLength('transaction_key', 36)
+            ->requirePresence('transaction_key', 'create')
+            ->notEmptyString('transaction_key');
 
         $validator
             ->requirePresence('type', 'create')
@@ -210,14 +210,14 @@ class AuditLogsTable extends Table
     {
         // Subquery to find transactions with many records
         $subquery = $this->find()
-            ->select(['transaction'])
-            ->groupBy(['transaction'])
+            ->select(['transaction_key'])
+            ->groupBy(['transaction_key'])
             ->having(function ($exp, $q) use ($minRecords) {
                 return $exp->gte($q->func()->count('*'), $minRecords, 'integer');
             });
 
         return $query->where([
-            'AuditLogs.transaction IN' => $subquery,
+            'AuditLogs.transaction_key IN' => $subquery,
         ]);
     }
 
@@ -233,14 +233,14 @@ class AuditLogsTable extends Table
     {
         // Subquery to find transactions with many records (bulk)
         $bulkSubquery = $this->find()
-            ->select(['transaction'])
-            ->groupBy(['transaction'])
+            ->select(['transaction_key'])
+            ->groupBy(['transaction_key'])
             ->having(function ($exp, $q) use ($minRecords) {
                 return $exp->gte($q->func()->count('*'), $minRecords, 'integer');
             });
 
         return $query->where([
-            'AuditLogs.transaction NOT IN' => $bulkSubquery,
+            'AuditLogs.transaction_key NOT IN' => $bulkSubquery,
         ]);
     }
 
@@ -256,7 +256,7 @@ class AuditLogsTable extends Table
     {
         return $query
             ->select([
-                'transaction' => 'AuditLogs.transaction',
+                'transaction_key' => 'AuditLogs.transaction_key',
                 'record_count' => $query->func()->count('*'),
                 'sources' => $query->func()->count(
                     $query->expr()->add('DISTINCT AuditLogs.source'),
@@ -265,7 +265,7 @@ class AuditLogsTable extends Table
                 'user_display' => $query->func()->max('AuditLogs.user_display'),
                 'created' => $query->func()->min('AuditLogs.created'),
             ])
-            ->groupBy(['AuditLogs.transaction'])
+            ->groupBy(['AuditLogs.transaction_key'])
             ->having(function ($exp, $q) use ($minRecords) {
                 return $exp->gte($q->func()->count('*'), $minRecords, 'integer');
             })

--- a/src/Monitor/Alert.php
+++ b/src/Monitor/Alert.php
@@ -93,7 +93,7 @@ class Alert
                 'type' => $this->auditLog->type->value,
                 'source' => $this->auditLog->source,
                 'primary_key' => $this->auditLog->primary_key,
-                'transaction' => $this->auditLog->transaction,
+                'transaction_key' => $this->auditLog->transaction_key,
                 'created' => $this->auditLog->created?->toIso8601String(),
             ],
             'context' => $this->context,

--- a/src/Persister/ElasticSearchPersister.php
+++ b/src/Persister/ElasticSearchPersister.php
@@ -126,7 +126,7 @@ class ElasticSearchPersister implements PersisterInterface
 
             $data = [
                 '@timestamp' => $log->getTimestamp(),
-                'transaction' => $log->getTransactionId(),
+                'transaction_key' => $log->getTransactionId(),
                 'type' => $eventType,
                 'primary_key' => $primary,
                 'source' => $log->getSourceName(),

--- a/src/Persister/ExtractionTrait.php
+++ b/src/Persister/ExtractionTrait.php
@@ -26,7 +26,7 @@ trait ExtractionTrait
     protected function extractBasicFields(EventInterface $event, bool $serialize = true): array
     {
         $fields = [
-            'transaction' => $event->getTransactionId(),
+            'transaction_key' => $event->getTransactionId(),
             'type' => $event->getEventType(),
             'source' => $event->getSourceName(),
             'parent_source' => null,

--- a/src/Service/GdprService.php
+++ b/src/Service/GdprService.php
@@ -169,7 +169,7 @@ class GdprService
         foreach ($this->findByUser($userId) as $log) {
             $data[] = [
                 'id' => $log->id,
-                'transaction' => $log->transaction,
+                'transaction_key' => $log->transaction_key,
                 'type' => $log->type->value ?? $log->type,
                 'source' => $log->source,
                 'primary_key' => $log->primary_key,

--- a/src/Service/RevertService.php
+++ b/src/Service/RevertService.php
@@ -205,7 +205,7 @@ class RevertService
         $auditLogs = $this->fetchTable('AuditStash.AuditLogs');
 
         $auditLog = $auditLogs->newEntity([
-            'transaction' => Text::uuid(),
+            'transaction_key' => Text::uuid(),
             'type' => AuditLogType::Revert,
             'source' => $source,
             'primary_key' => (string)$primaryKey,

--- a/templates/Admin/AuditLogs/bulk_changes.php
+++ b/templates/Admin/AuditLogs/bulk_changes.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var array<array{transaction: string, record_count: int, sources: int, user_id: string|null, user_display: string|null, created: \Cake\I18n\DateTime|null}> $bulkStats
+ * @var array<array{transaction_key: string, record_count: int, sources: int, user_id: string|null, user_display: string|null, created: \Cake\I18n\DateTime|null}> $bulkStats
  * @var int $minRecords
  */
 ?>
@@ -66,7 +66,7 @@
                     <?php foreach ($bulkStats as $stat) { ?>
                         <tr>
                             <td>
-                                <code class="small"><?= h($stat['transaction']) ?></code>
+                                <code class="small"><?= h($stat['transaction_key']) ?></code>
                             </td>
                             <td>
                                 <span class="badge bg-<?= $stat['record_count'] >= 100 ? 'danger' : ($stat['record_count'] >= 20 ? 'warning' : 'info') ?>">
@@ -81,7 +81,7 @@
                             <td>
                                 <?= $this->Html->link(
                                     __('View All'),
-                                    ['action' => 'index', '?' => ['transaction' => $stat['transaction']]],
+                                    ['action' => 'index', '?' => ['transaction_key' => $stat['transaction_key']]],
                                     ['class' => 'btn btn-sm btn-outline-primary']
                                 ) ?>
                             </td>

--- a/templates/Admin/AuditLogs/index.php
+++ b/templates/Admin/AuditLogs/index.php
@@ -75,7 +75,7 @@
                     ]) ?>
                 </div>
                 <div class="col-md-3">
-                    <?= $this->Form->control('transaction', [
+                    <?= $this->Form->control('transaction_key', [
                         'type' => 'text',
                         'label' => 'Transaction ID',
                         'placeholder' => 'Transaction ID',

--- a/templates/Admin/AuditLogs/related_changes.php
+++ b/templates/Admin/AuditLogs/related_changes.php
@@ -3,7 +3,7 @@
  * @var \App\View\AppView $this
  * @var string $source
  * @var string $primaryKey
- * @var array<string, array{transaction: string, created: \Cake\I18n\DateTime|null, user_id: string|null, user_display: string|null, logs: array<\AuditStash\Model\Entity\AuditLog>}> $transactions
+ * @var array<string, array{transaction_key: string, created: \Cake\I18n\DateTime|null, user_id: string|null, user_display: string|null, logs: array<\AuditStash\Model\Entity\AuditLog>}> $transactions
  */
 ?>
 <div class="auditLogs related-changes content">
@@ -41,7 +41,7 @@
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
                             <strong><?= __('Transaction:') ?></strong>
-                            <code class="small"><?= h($transaction['transaction']) ?></code>
+                            <code class="small"><?= h($transaction['transaction_key']) ?></code>
                         </div>
                         <div class="text-muted small">
                             <?= h($transaction['created']) ?>

--- a/templates/Admin/AuditLogs/timeline.php
+++ b/templates/Admin/AuditLogs/timeline.php
@@ -97,7 +97,7 @@ use AuditStash\AuditLogType;
                                         <div class="col-md-6 text-end">
                                             <small class="text-muted">
                                                 <strong>Transaction:</strong>
-                                                <?= $this->Audit->transactionId($auditLog->transaction) ?>
+                                                <?= $this->Audit->transactionId($auditLog->transaction_key) ?>
                                             </small>
                                         </div>
                                     </div>

--- a/templates/Admin/AuditLogs/view.php
+++ b/templates/Admin/AuditLogs/view.php
@@ -51,7 +51,7 @@ use AuditStash\AuditLogType;
                         </tr>
                         <tr>
                             <th><?= __('Transaction ID') ?></th>
-                            <td><?= $this->Audit->transactionId($auditLog->transaction, true) ?></td>
+                            <td><?= $this->Audit->transactionId($auditLog->transaction_key, true) ?></td>
                         </tr>
                         <tr>
                             <th><?= __('User') ?></th>

--- a/templates/email/html/audit_alert.php
+++ b/templates/email/html/audit_alert.php
@@ -113,7 +113,7 @@ $severityColor = $severityColors[$alert->getSeverity()] ?? '#6c757d';
                     </tr>
                     <tr>
                         <td>Transaction</td>
-                        <td><code><?= h($auditLog->transaction) ?></code></td>
+                        <td><code><?= h($auditLog->transaction_key) ?></code></td>
                     </tr>
                     <tr>
                         <td>Timestamp</td>

--- a/templates/email/text/audit_alert.php
+++ b/templates/email/text/audit_alert.php
@@ -28,7 +28,7 @@ Table: <?= $auditLog->source ?>
 
 Primary Key: <?= $auditLog->primary_key ?>
 
-Transaction: <?= $auditLog->transaction ?>
+Transaction: <?= $auditLog->transaction_key ?>
 
 Timestamp: <?= $auditLog->created ? $auditLog->created->format('Y-m-d H:i:s') : 'N/A' ?>
 

--- a/tests/AuditLogsTable.php
+++ b/tests/AuditLogsTable.php
@@ -17,7 +17,7 @@ class AuditLogsTable extends Table
 
         $this->setSchema([
             'id' => 'integer',
-            'transaction' => 'binaryuuid',
+            'transaction_key' => 'binaryuuid',
             'type' => 'string',
             'primary_key' => 'integer',
             'source' => 'string',

--- a/tests/Fixture/AuditLogsFixture.php
+++ b/tests/Fixture/AuditLogsFixture.php
@@ -18,7 +18,7 @@ class AuditLogsFixture extends TestFixture
      */
     public array $fields = [
         'id' => ['type' => 'integer', 'length' => 10, 'unsigned' => true, 'null' => false, 'default' => null, 'autoIncrement' => true],
-        'transaction' => ['type' => 'string', 'length' => 36, 'null' => false, 'default' => null],
+        'transaction_key' => ['type' => 'string', 'length' => 36, 'null' => false, 'default' => null],
         'type' => ['type' => 'string', 'length' => 7, 'null' => false, 'default' => null],
         'primary_key' => ['type' => 'integer', 'length' => 10, 'unsigned' => true, 'null' => true, 'default' => null],
         'display_value' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null],
@@ -34,7 +34,7 @@ class AuditLogsFixture extends TestFixture
             'primary' => ['type' => 'primary', 'columns' => ['id']],
         ],
         '_indexes' => [
-            'idx_transaction' => ['type' => 'index', 'columns' => ['transaction']],
+            'idx_transaction_key' => ['type' => 'index', 'columns' => ['transaction_key']],
             'idx_type' => ['type' => 'index', 'columns' => ['type']],
             'idx_primary_key' => ['type' => 'index', 'columns' => ['primary_key']],
             'idx_display_value' => ['type' => 'index', 'columns' => ['display_value']],

--- a/tests/TestCase/Command/CleanupCommandTest.php
+++ b/tests/TestCase/Command/CleanupCommandTest.php
@@ -83,7 +83,7 @@ class CleanupCommandTest extends TestCase
 
         // Create old audit log
         $oldLog = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -116,7 +116,7 @@ class CleanupCommandTest extends TestCase
 
         // Create old audit log
         $oldLog = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -147,7 +147,7 @@ class CleanupCommandTest extends TestCase
 
         // Create old logs for different tables
         $oldLog1 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -156,7 +156,7 @@ class CleanupCommandTest extends TestCase
         $auditLogsTable->save($oldLog1);
 
         $oldLog2 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-2',
+            'transaction_key' => 'test-transaction-2',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,
@@ -191,7 +191,7 @@ class CleanupCommandTest extends TestCase
 
         // Create logs of different ages
         $log1 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -200,7 +200,7 @@ class CleanupCommandTest extends TestCase
         $auditLogsTable->save($log1);
 
         $log2 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-2',
+            'transaction_key' => 'test-transaction-2',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 2,
@@ -233,7 +233,7 @@ class CleanupCommandTest extends TestCase
 
         // Create old log
         $oldLog = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,
@@ -266,7 +266,7 @@ class CleanupCommandTest extends TestCase
 
         // Create old logs for different tables
         $oldLog1 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'Users',
             'primary_key' => 1,
@@ -275,7 +275,7 @@ class CleanupCommandTest extends TestCase
         $auditLogsTable->save($oldLog1);
 
         $oldLog2 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-2',
+            'transaction_key' => 'test-transaction-2',
             'type' => 'update',
             'source' => 'Orders',
             'primary_key' => 1,
@@ -313,7 +313,7 @@ class CleanupCommandTest extends TestCase
 
         // Create old log for a table with disabled retention
         $oldLog = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'ComplianceLogs',
             'primary_key' => 1,
@@ -420,7 +420,7 @@ class CleanupCommandTest extends TestCase
 
         // Create old log for a plugin-prefixed table
         $oldLog = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'MyPlugin.Users',
             'primary_key' => 1,

--- a/tests/TestCase/Command/GdprCommandTest.php
+++ b/tests/TestCase/Command/GdprCommandTest.php
@@ -80,7 +80,7 @@ class GdprCommandTest extends TestCase
 
         // Create logs for user
         $log1 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'articles',
             'primary_key' => 1,
@@ -91,7 +91,7 @@ class GdprCommandTest extends TestCase
         $auditLogsTable->save($log1);
 
         $log2 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-2',
+            'transaction_key' => 'test-transaction-2',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -118,7 +118,7 @@ class GdprCommandTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,
@@ -154,7 +154,7 @@ class GdprCommandTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,
@@ -202,7 +202,7 @@ class GdprCommandTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,
@@ -232,7 +232,7 @@ class GdprCommandTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,
@@ -263,7 +263,7 @@ class GdprCommandTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,
@@ -292,7 +292,7 @@ class GdprCommandTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -322,7 +322,7 @@ class GdprCommandTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -415,7 +415,7 @@ class GdprCommandTest extends TestCase
 
         // Create logs for user 123
         $log1 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -427,7 +427,7 @@ class GdprCommandTest extends TestCase
 
         // Create logs for user 456
         $log2 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-2',
+            'transaction_key' => 'test-transaction-2',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 2,

--- a/tests/TestCase/Controller/AuditLogsControllerTest.php
+++ b/tests/TestCase/Controller/AuditLogsControllerTest.php
@@ -51,7 +51,7 @@ class AuditLogsControllerTest extends TestCase
 
         // Create test logs
         $log1 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'articles',
             'primary_key' => 1,
@@ -61,7 +61,7 @@ class AuditLogsControllerTest extends TestCase
         $auditLogsTable->save($log1);
 
         $log2 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-2',
+            'transaction_key' => 'test-transaction-2',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 2,
@@ -114,7 +114,7 @@ class AuditLogsControllerTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'articles',
             'primary_key' => 1,
@@ -146,7 +146,7 @@ class AuditLogsControllerTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -184,7 +184,7 @@ class AuditLogsControllerTest extends TestCase
 
         // Create multiple logs for same record
         $log1 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'articles',
             'primary_key' => 1,
@@ -194,7 +194,7 @@ class AuditLogsControllerTest extends TestCase
         $auditLogsTable->save($log1);
 
         $log2 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-2',
+            'transaction_key' => 'test-transaction-2',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -246,7 +246,7 @@ class AuditLogsControllerTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -281,7 +281,7 @@ class AuditLogsControllerTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -308,7 +308,7 @@ class AuditLogsControllerTest extends TestCase
         $this->assertIsArray($data);
         $this->assertNotEmpty($data);
         $this->assertArrayHasKey('id', $data[0]);
-        $this->assertArrayHasKey('transaction', $data[0]);
+        $this->assertArrayHasKey('transaction_key', $data[0]);
         $this->assertArrayHasKey('type', $data[0]);
     }
 
@@ -322,7 +322,7 @@ class AuditLogsControllerTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log1 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'articles',
             'primary_key' => 1,
@@ -331,7 +331,7 @@ class AuditLogsControllerTest extends TestCase
         $auditLogsTable->save($log1);
 
         $log2 = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-2',
+            'transaction_key' => 'test-transaction-2',
             'type' => 'create',
             'source' => 'users',
             'primary_key' => 2,
@@ -397,7 +397,7 @@ class AuditLogsControllerTest extends TestCase
 
         // Create audit log
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'update',
             'source' => 'Articles',
             'primary_key' => '1',
@@ -430,7 +430,7 @@ class AuditLogsControllerTest extends TestCase
 
         // Create delete audit log
         $deleteLog = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-delete',
+            'transaction_key' => 'test-transaction-delete',
             'type' => 'delete',
             'source' => 'Articles',
             'primary_key' => '99',
@@ -480,7 +480,7 @@ class AuditLogsControllerTest extends TestCase
 
         // Create audit log
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'Articles',
             'primary_key' => '10',
@@ -530,7 +530,7 @@ class AuditLogsControllerTest extends TestCase
 
         // Create audit log
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'Articles',
             'primary_key' => '11',
@@ -571,7 +571,7 @@ class AuditLogsControllerTest extends TestCase
 
         // Create a revert audit log
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-revert',
+            'transaction_key' => 'test-transaction-revert',
             'type' => 'revert',
             'source' => 'Articles',
             'primary_key' => '1',
@@ -609,7 +609,7 @@ class AuditLogsControllerTest extends TestCase
         // Create various log types for the same record
         $logs = [
             [
-                'transaction' => 'test-transaction-1',
+                'transaction_key' => 'test-transaction-1',
                 'type' => 'create',
                 'source' => 'Articles',
                 'primary_key' => '5',
@@ -617,7 +617,7 @@ class AuditLogsControllerTest extends TestCase
                 'created' => new DateTime('-3 days'),
             ],
             [
-                'transaction' => 'test-transaction-2',
+                'transaction_key' => 'test-transaction-2',
                 'type' => 'update',
                 'source' => 'Articles',
                 'primary_key' => '5',
@@ -626,7 +626,7 @@ class AuditLogsControllerTest extends TestCase
                 'created' => new DateTime('-2 days'),
             ],
             [
-                'transaction' => 'test-transaction-3',
+                'transaction_key' => 'test-transaction-3',
                 'type' => 'revert',
                 'source' => 'Articles',
                 'primary_key' => '5',
@@ -639,7 +639,7 @@ class AuditLogsControllerTest extends TestCase
                 'created' => new DateTime('-1 day'),
             ],
             [
-                'transaction' => 'test-transaction-4',
+                'transaction_key' => 'test-transaction-4',
                 'type' => 'delete',
                 'source' => 'Articles',
                 'primary_key' => '5',
@@ -693,7 +693,7 @@ class AuditLogsControllerTest extends TestCase
 
         // Create audit log with same state
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'Articles',
             'primary_key' => '20',
@@ -737,7 +737,7 @@ class AuditLogsControllerTest extends TestCase
 
         // Create audit log with different state
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'Articles',
             'primary_key' => '21',
@@ -798,7 +798,7 @@ class AuditLogsControllerTest extends TestCase
 
         // Create delete audit log
         $deleteLog = $auditLogsTable->newEntity([
-            'transaction' => 'test-transaction-delete',
+            'transaction_key' => 'test-transaction-delete',
             'type' => 'delete',
             'source' => 'Articles',
             'primary_key' => '98',

--- a/tests/TestCase/Model/Table/AuditLogsTableTest.php
+++ b/tests/TestCase/Model/Table/AuditLogsTableTest.php
@@ -49,7 +49,7 @@ class AuditLogsTableTest extends TestCase
     {
         // Create test logs with different changed fields
         $log1 = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-1',
+            'transaction_key' => 'test-tx-1',
             'type' => 'update',
             'source' => 'Articles',
             'primary_key' => 1,
@@ -59,7 +59,7 @@ class AuditLogsTableTest extends TestCase
         $this->getAuditLogsTable()->save($log1);
 
         $log2 = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-2',
+            'transaction_key' => 'test-tx-2',
             'type' => 'update',
             'source' => 'Articles',
             'primary_key' => 2,
@@ -69,7 +69,7 @@ class AuditLogsTableTest extends TestCase
         $this->getAuditLogsTable()->save($log2);
 
         $log3 = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-3',
+            'transaction_key' => 'test-tx-3',
             'type' => 'update',
             'source' => 'Articles',
             'primary_key' => 3,
@@ -99,7 +99,7 @@ class AuditLogsTableTest extends TestCase
     {
         // Create test logs with different field values
         $log1 = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-1',
+            'transaction_key' => 'test-tx-1',
             'type' => 'update',
             'source' => 'Articles',
             'primary_key' => 1,
@@ -109,7 +109,7 @@ class AuditLogsTableTest extends TestCase
         $this->getAuditLogsTable()->save($log1);
 
         $log2 = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-2',
+            'transaction_key' => 'test-tx-2',
             'type' => 'update',
             'source' => 'Articles',
             'primary_key' => 2,
@@ -119,7 +119,7 @@ class AuditLogsTableTest extends TestCase
         $this->getAuditLogsTable()->save($log2);
 
         $log3 = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-3',
+            'transaction_key' => 'test-tx-3',
             'type' => 'update',
             'source' => 'Articles',
             'primary_key' => 3,
@@ -152,7 +152,7 @@ class AuditLogsTableTest extends TestCase
     {
         // Create a main record log
         $mainLog = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-1',
+            'transaction_key' => 'test-tx-1',
             'type' => 'create',
             'source' => 'Articles',
             'primary_key' => 1,
@@ -163,7 +163,7 @@ class AuditLogsTableTest extends TestCase
 
         // Create a related record log (comment on the article)
         $relatedLog = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-1',
+            'transaction_key' => 'test-tx-1',
             'type' => 'create',
             'source' => 'Comments',
             'primary_key' => 1,
@@ -175,7 +175,7 @@ class AuditLogsTableTest extends TestCase
 
         // Create an unrelated log
         $unrelatedLog = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-2',
+            'transaction_key' => 'test-tx-2',
             'type' => 'create',
             'source' => 'Users',
             'primary_key' => 1,
@@ -205,7 +205,7 @@ class AuditLogsTableTest extends TestCase
         $bulkTxId = 'bulk-tx-123';
         for ($i = 1; $i <= 10; $i++) {
             $log = $this->getAuditLogsTable()->newEntity([
-                'transaction' => $bulkTxId,
+                'transaction_key' => $bulkTxId,
                 'type' => 'create',
                 'source' => 'Articles',
                 'primary_key' => $i,
@@ -219,7 +219,7 @@ class AuditLogsTableTest extends TestCase
         $smallTxId = 'small-tx-456';
         for ($i = 1; $i <= 2; $i++) {
             $log = $this->getAuditLogsTable()->newEntity([
-                'transaction' => $smallTxId,
+                'transaction_key' => $smallTxId,
                 'type' => 'update',
                 'source' => 'Users',
                 'primary_key' => $i,
@@ -234,7 +234,7 @@ class AuditLogsTableTest extends TestCase
 
         $this->assertCount(10, $results);
         foreach ($results as $log) {
-            $this->assertEquals($bulkTxId, $log->transaction);
+            $this->assertEquals($bulkTxId, $log->transaction_key);
         }
 
         // Find bulk changes with higher threshold (8)
@@ -259,7 +259,7 @@ class AuditLogsTableTest extends TestCase
         $bulkTxId = 'bulk-tx-non-123';
         for ($i = 1; $i <= 10; $i++) {
             $log = $this->getAuditLogsTable()->newEntity([
-                'transaction' => $bulkTxId,
+                'transaction_key' => $bulkTxId,
                 'type' => 'create',
                 'source' => 'Articles',
                 'primary_key' => $i,
@@ -273,7 +273,7 @@ class AuditLogsTableTest extends TestCase
         $smallTxId = 'small-tx-non-456';
         for ($i = 1; $i <= 2; $i++) {
             $log = $this->getAuditLogsTable()->newEntity([
-                'transaction' => $smallTxId,
+                'transaction_key' => $smallTxId,
                 'type' => 'update',
                 'source' => 'Users',
                 'primary_key' => $i,
@@ -288,7 +288,7 @@ class AuditLogsTableTest extends TestCase
 
         $this->assertCount(2, $results);
         foreach ($results as $log) {
-            $this->assertEquals($smallTxId, $log->transaction);
+            $this->assertEquals($smallTxId, $log->transaction_key);
         }
 
         // Find non-bulk changes with higher threshold (8) - should still get only small transaction
@@ -315,7 +315,7 @@ class AuditLogsTableTest extends TestCase
 
         for ($i = 1; $i <= 5; $i++) {
             $log = $this->getAuditLogsTable()->newEntity([
-                'transaction' => $bulkTxId,
+                'transaction_key' => $bulkTxId,
                 'type' => 'create',
                 'source' => 'Articles',
                 'primary_key' => $i,
@@ -329,7 +329,7 @@ class AuditLogsTableTest extends TestCase
 
         for ($i = 1; $i <= 3; $i++) {
             $log = $this->getAuditLogsTable()->newEntity([
-                'transaction' => $bulkTxId,
+                'transaction_key' => $bulkTxId,
                 'type' => 'create',
                 'source' => 'Comments',
                 'primary_key' => $i,
@@ -344,7 +344,7 @@ class AuditLogsTableTest extends TestCase
         // Create a small transaction (should not appear in results)
         $smallTxId = 'small-tx-111';
         $log = $this->getAuditLogsTable()->newEntity([
-            'transaction' => $smallTxId,
+            'transaction_key' => $smallTxId,
             'type' => 'update',
             'source' => 'Users',
             'primary_key' => 1,
@@ -359,7 +359,7 @@ class AuditLogsTableTest extends TestCase
         $this->assertCount(1, $results);
         $stat = $results[0];
 
-        $this->assertEquals($bulkTxId, $stat['transaction']);
+        $this->assertEquals($bulkTxId, $stat['transaction_key']);
         $this->assertEquals(8, (int)$stat['record_count']);
         $this->assertEquals(2, (int)$stat['sources']);
         // user_id and user_display are included via MAX aggregate
@@ -377,7 +377,7 @@ class AuditLogsTableTest extends TestCase
     {
         // Create logs with various fields
         $log1 = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-1',
+            'transaction_key' => 'test-tx-1',
             'type' => 'update',
             'source' => 'Articles',
             'primary_key' => 1,
@@ -387,7 +387,7 @@ class AuditLogsTableTest extends TestCase
         $this->getAuditLogsTable()->save($log1);
 
         $log2 = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-2',
+            'transaction_key' => 'test-tx-2',
             'type' => 'update',
             'source' => 'Users',
             'primary_key' => 1,
@@ -397,7 +397,7 @@ class AuditLogsTableTest extends TestCase
         $this->getAuditLogsTable()->save($log2);
 
         $log3 = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-3',
+            'transaction_key' => 'test-tx-3',
             'type' => 'update',
             'source' => 'Articles',
             'primary_key' => 2,
@@ -429,7 +429,7 @@ class AuditLogsTableTest extends TestCase
     {
         // Create a main record with PascalCase source name
         $mainLog = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-1',
+            'transaction_key' => 'test-tx-1',
             'type' => 'create',
             'source' => 'UserProfiles',
             'primary_key' => 1,
@@ -440,7 +440,7 @@ class AuditLogsTableTest extends TestCase
 
         // Create a related record with snake_case foreign key
         $relatedLog = $this->getAuditLogsTable()->newEntity([
-            'transaction' => 'test-tx-1',
+            'transaction_key' => 'test-tx-1',
             'type' => 'create',
             'source' => 'ProfilePhotos',
             'primary_key' => 1,

--- a/tests/TestCase/Monitor/Channel/LogChannelTest.php
+++ b/tests/TestCase/Monitor/Channel/LogChannelTest.php
@@ -60,7 +60,7 @@ class LogChannelTest extends TestCase
             'type' => AuditLogType::Delete,
             'source' => 'users',
             'primary_key' => 123,
-            'transaction' => 'abc-123',
+            'transaction_key' => 'abc-123',
             'created' => DateTime::now(),
         ]);
 
@@ -102,7 +102,7 @@ class LogChannelTest extends TestCase
                 'type' => AuditLogType::Delete,
                 'source' => 'test',
                 'primary_key' => 1,
-                'transaction' => 'test',
+                'transaction_key' => 'test',
             ]);
 
             $alert = new Alert(

--- a/tests/TestCase/Monitor/Rule/MassDeleteRuleTest.php
+++ b/tests/TestCase/Monitor/Rule/MassDeleteRuleTest.php
@@ -41,7 +41,7 @@ class MassDeleteRuleTest extends TestCase
         for ($i = 0; $i < 3; $i++) {
             $auditLogsTable->save($auditLogsTable->newEntity([
                 'type' => AuditLogType::Delete,
-                'transaction' => 'test-' . $i,
+                'transaction_key' => 'test-' . $i,
                 'source' => 'users',
                 'primary_key' => $i + 1,
             ]));
@@ -49,7 +49,7 @@ class MassDeleteRuleTest extends TestCase
 
         $testLog = $auditLogsTable->newEntity([
             'type' => AuditLogType::Delete,
-            'transaction' => 'test',
+            'transaction_key' => 'test',
             'source' => 'users',
             'primary_key' => 999,
         ]);
@@ -145,7 +145,7 @@ class MassDeleteRuleTest extends TestCase
         for ($i = 0; $i < 5; $i++) {
             $auditLogsTable->save($auditLogsTable->newEntity([
                 'type' => AuditLogType::Delete,
-                'transaction' => 'test-' . $i,
+                'transaction_key' => 'test-' . $i,
                 'source' => 'posts',
                 'primary_key' => $i + 1,
             ]));

--- a/tests/TestCase/Persister/ElasticSearchPersisterIntegrationTest.php
+++ b/tests/TestCase/Persister/ElasticSearchPersisterIntegrationTest.php
@@ -62,7 +62,7 @@ class ElasticSearchPersisterIntegrationTest extends TestCase
         );
 
         $expected = [
-            'transaction' => '1234',
+            'transaction_key' => '1234',
             'type' => 'create',
             'primary_key' => 50,
             'source' => 'articles',
@@ -119,7 +119,7 @@ class ElasticSearchPersisterIntegrationTest extends TestCase
             new DateTime($articles[0]->get('@timestamp')),
         );
         $expected = [
-            'transaction' => '1234',
+            'transaction_key' => '1234',
             'type' => 'update',
             'primary_key' => 50,
             'source' => 'articles',
@@ -158,7 +158,7 @@ class ElasticSearchPersisterIntegrationTest extends TestCase
         );
 
         $expected = [
-            'transaction' => '1234',
+            'transaction_key' => '1234',
             'type' => 'delete',
             'primary_key' => 50,
             'source' => 'articles',
@@ -250,7 +250,7 @@ class ElasticSearchPersisterIntegrationTest extends TestCase
         );
 
         $expected = [
-            'transaction' => '1234',
+            'transaction_key' => '1234',
             'type' => 'update',
             'primary_key' => 50,
             'source' => 'articles',

--- a/tests/TestCase/Persister/TablePersisterTest.php
+++ b/tests/TestCase/Persister/TablePersisterTest.php
@@ -119,7 +119,7 @@ class TablePersisterTest extends TestCase
         $event->setMetaInfo([]);
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -159,7 +159,7 @@ class TablePersisterTest extends TestCase
         ]);
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -206,7 +206,7 @@ class TablePersisterTest extends TestCase
         ]);
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -249,7 +249,7 @@ class TablePersisterTest extends TestCase
         ]);
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -291,7 +291,7 @@ class TablePersisterTest extends TestCase
         ]);
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -334,7 +334,7 @@ class TablePersisterTest extends TestCase
             ->getMock();
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -404,7 +404,7 @@ class TablePersisterTest extends TestCase
         $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', [1, 2, 3], 'source', [], [], new Entity());
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -438,7 +438,7 @@ class TablePersisterTest extends TestCase
         $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 1, 'source', [], [], new Entity());
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -473,7 +473,7 @@ class TablePersisterTest extends TestCase
         $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', [1, 2, 3], 'source', [], [], new Entity());
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -510,7 +510,7 @@ class TablePersisterTest extends TestCase
         $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 1, 'source', [], [], new Entity());
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -545,7 +545,7 @@ class TablePersisterTest extends TestCase
         $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', [1, 2, 3], 'source', [], [], new Entity());
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -582,7 +582,7 @@ class TablePersisterTest extends TestCase
         $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 'pk', 'source', [], [], new Entity());
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -619,7 +619,7 @@ class TablePersisterTest extends TestCase
         $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', [1, 2, 3], 'source', [], [], new Entity());
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -659,7 +659,7 @@ class TablePersisterTest extends TestCase
         ]);
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -705,7 +705,7 @@ class TablePersisterTest extends TestCase
         ]);
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -742,7 +742,7 @@ class TablePersisterTest extends TestCase
         ]);
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,
@@ -778,7 +778,7 @@ class TablePersisterTest extends TestCase
         ]);
 
         $entity = new Entity([
-            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'transaction_key' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
             'type' => 'create',
             'source' => 'source',
             'parent_source' => null,

--- a/tests/TestCase/Service/GdprServiceTest.php
+++ b/tests/TestCase/Service/GdprServiceTest.php
@@ -49,7 +49,7 @@ class GdprServiceTest extends TestCase
 
         // Create logs for different users
         $log1 = $auditLogsTable->newEntity([
-            'transaction' => 'test-1',
+            'transaction_key' => 'test-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -59,7 +59,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable->save($log1);
 
         $log2 = $auditLogsTable->newEntity([
-            'transaction' => 'test-2',
+            'transaction_key' => 'test-2',
             'type' => 'create',
             'source' => 'comments',
             'primary_key' => 1,
@@ -69,7 +69,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable->save($log2);
 
         $log3 = $auditLogsTable->newEntity([
-            'transaction' => 'test-3',
+            'transaction_key' => 'test-3',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 2,
@@ -94,7 +94,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log1 = $auditLogsTable->newEntity([
-            'transaction' => 'test-1',
+            'transaction_key' => 'test-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -104,7 +104,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable->save($log1);
 
         $log2 = $auditLogsTable->newEntity([
-            'transaction' => 'test-2',
+            'transaction_key' => 'test-2',
             'type' => 'create',
             'source' => 'articles',
             'primary_key' => 2,
@@ -114,7 +114,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable->save($log2);
 
         $log3 = $auditLogsTable->newEntity([
-            'transaction' => 'test-3',
+            'transaction_key' => 'test-3',
             'type' => 'delete',
             'source' => 'comments',
             'primary_key' => 1,
@@ -156,7 +156,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-1',
+            'transaction_key' => 'test-1',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,
@@ -208,7 +208,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-1',
+            'transaction_key' => 'test-1',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,
@@ -235,7 +235,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-1',
+            'transaction_key' => 'test-1',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,
@@ -262,7 +262,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-1',
+            'transaction_key' => 'test-1',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,
@@ -297,7 +297,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log1 = $auditLogsTable->newEntity([
-            'transaction' => 'test-1',
+            'transaction_key' => 'test-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 1,
@@ -307,7 +307,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable->save($log1);
 
         $log2 = $auditLogsTable->newEntity([
-            'transaction' => 'test-2',
+            'transaction_key' => 'test-2',
             'type' => 'create',
             'source' => 'comments',
             'primary_key' => 1,
@@ -317,7 +317,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable->save($log2);
 
         $log3 = $auditLogsTable->newEntity([
-            'transaction' => 'test-3',
+            'transaction_key' => 'test-3',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 2,
@@ -348,7 +348,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-1',
+            'transaction_key' => 'test-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 42,
@@ -382,7 +382,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-1',
+            'transaction_key' => 'test-1',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => 42,
@@ -411,7 +411,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-1',
+            'transaction_key' => 'test-1',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,
@@ -442,7 +442,7 @@ class GdprServiceTest extends TestCase
         $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
 
         $log = $auditLogsTable->newEntity([
-            'transaction' => 'test-1',
+            'transaction_key' => 'test-1',
             'type' => 'update',
             'source' => 'users',
             'primary_key' => 1,

--- a/tests/TestCase/Service/RevertServiceTest.php
+++ b/tests/TestCase/Service/RevertServiceTest.php
@@ -55,7 +55,7 @@ class RevertServiceTest extends TestCase
 
         // Create audit log (original state)
         $createLog = $auditLogs->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'Articles',
             'primary_key' => '1',
@@ -66,7 +66,7 @@ class RevertServiceTest extends TestCase
 
         // Update audit log
         $updateLog = $auditLogs->newEntity([
-            'transaction' => 'test-transaction-2',
+            'transaction_key' => 'test-transaction-2',
             'type' => 'update',
             'source' => 'Articles',
             'primary_key' => '1',
@@ -116,7 +116,7 @@ class RevertServiceTest extends TestCase
         $auditLogs = $this->fetchTable('AuditStash.AuditLogs');
 
         $createLog = $auditLogs->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'Articles',
             'primary_key' => '2',
@@ -153,7 +153,7 @@ class RevertServiceTest extends TestCase
         $auditLogs = $this->fetchTable('AuditStash.AuditLogs');
 
         $deleteLog = $auditLogs->newEntity([
-            'transaction' => 'test-transaction-delete',
+            'transaction_key' => 'test-transaction-delete',
             'type' => 'delete',
             'source' => 'Articles',
             'primary_key' => '99',
@@ -211,7 +211,7 @@ class RevertServiceTest extends TestCase
         $auditLogs = $this->fetchTable('AuditStash.AuditLogs');
 
         $createLog = $auditLogs->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'Articles',
             'primary_key' => '999',
@@ -245,7 +245,7 @@ class RevertServiceTest extends TestCase
         // Create delete audit log for same ID
         $auditLogs = $this->fetchTable('AuditStash.AuditLogs');
         $deleteLog = $auditLogs->newEntity([
-            'transaction' => 'test-transaction-delete',
+            'transaction_key' => 'test-transaction-delete',
             'type' => 'delete',
             'source' => 'Articles',
             'primary_key' => '50',
@@ -284,7 +284,7 @@ class RevertServiceTest extends TestCase
         // Create audit log
         $auditLogs = $this->fetchTable('AuditStash.AuditLogs');
         $createLog = $auditLogs->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'Articles',
             'primary_key' => '3',

--- a/tests/TestCase/Service/StateReconstructorServiceTest.php
+++ b/tests/TestCase/Service/StateReconstructorServiceTest.php
@@ -41,7 +41,7 @@ class StateReconstructorServiceTest extends TestCase
 
         // Create initial state
         $log1 = $auditLogs->newEntity([
-            'transaction' => 'test-transaction-1',
+            'transaction_key' => 'test-transaction-1',
             'type' => 'create',
             'source' => 'articles',
             'primary_key' => '1',
@@ -52,7 +52,7 @@ class StateReconstructorServiceTest extends TestCase
 
         // Update 1
         $log2 = $auditLogs->newEntity([
-            'transaction' => 'test-transaction-2',
+            'transaction_key' => 'test-transaction-2',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => '1',
@@ -63,7 +63,7 @@ class StateReconstructorServiceTest extends TestCase
 
         // Update 2
         $log3 = $auditLogs->newEntity([
-            'transaction' => 'test-transaction-3',
+            'transaction_key' => 'test-transaction-3',
             'type' => 'update',
             'source' => 'articles',
             'primary_key' => '1',

--- a/tests/mappings.php
+++ b/tests/mappings.php
@@ -7,7 +7,7 @@ return [
         'mapping' => [
             'id' => ['type' => 'integer'],
             '@timestamp' => ['type' => 'date'],
-            'transaction' => ['type' => 'text', 'index' => false],
+            'transaction_key' => ['type' => 'text', 'index' => false],
             'type' => ['type' => 'text', 'index' => false],
             'primary_key' => ['type' => 'integer'],
             'source' => ['type' => 'text', 'index' => false],
@@ -39,7 +39,7 @@ return [
         'mapping' => [
             'id' => ['type' => 'integer'],
             '@timestamp' => ['type' => 'date'],
-            'transaction' => ['type' => 'text', 'index' => false],
+            'transaction_key' => ['type' => 'text', 'index' => false],
             'type' => ['type' => 'text', 'index' => false],
             'primary_key' => ['type' => 'integer'],
             'source' => ['type' => 'text', 'index' => false],
@@ -63,7 +63,7 @@ return [
         'mapping' => [
             'id' => ['type' => 'integer'],
             '@timestamp' => ['type' => 'date'],
-            'transaction' => ['type' => 'text', 'index' => false],
+            'transaction_key' => ['type' => 'text', 'index' => false],
             'type' => ['type' => 'text', 'index' => false],
             'primary_key' => ['type' => 'integer'],
             'source' => ['type' => 'text', 'index' => false],
@@ -87,7 +87,7 @@ return [
         'mapping' => [
             'id' => ['type' => 'integer'],
             '@timestamp' => ['type' => 'date'],
-            'transaction' => ['type' => 'text', 'index' => false],
+            'transaction_key' => ['type' => 'text', 'index' => false],
             'type' => ['type' => 'text', 'index' => false],
             'primary_key' => ['type' => 'integer'],
             'source' => ['type' => 'text', 'index' => false],


### PR DESCRIPTION
## Summary

- Renames the `transaction` column to `transaction_key` in the `audit_logs` table to avoid SQL reserved keyword conflicts (notably SQLite, see lorenzo/audit-stash#37)
- Includes a migration (`20260416120000`) for existing installations to rename the column
- Updates all source code, templates, tests, and documentation references

Existing users need to run `bin/cake migrations migrate -p AuditStash` after updating.