### PR TITLE
fix: make RenameTransactionToTransactionKey idempotent on fresh installs

### DIFF
--- a/config/Migrations/20260416120000_RenameTransactionToTransactionKey.php
+++ b/config/Migrations/20260416120000_RenameTransactionToTransactionKey.php
@@ -8,15 +8,17 @@ class RenameTransactionToTransactionKey extends BaseMigration
 {
     public function up(): void
     {
-        $this->table('audit_logs')
-            ->renameColumn('transaction', 'transaction_key')
-            ->update();
+        $table = $this->table('audit_logs');
+        if ($table->hasColumn('transaction')) {
+            $table->renameColumn('transaction', 'transaction_key')->update();
+        }
     }
 
     public function down(): void
     {
-        $this->table('audit_logs')
-            ->renameColumn('transaction_key', 'transaction')
-            ->update();
+        $table = $this->table('audit_logs');
+        if ($table->hasColumn('transaction_key') && !$table->hasColumn('transaction')) {
+            $table->renameColumn('transaction_key', 'transaction')->update();
+        }
     }
-}
+}s


### PR DESCRIPTION
## Problem

On a fresh install, `bin/cake migrations migrate -p AuditStash` fails with:

== 20260416120000 RenameTransactionToTransactionKey: migrating
The specified column doesn't exist: transaction

Root cause: PR #39 retroactively updated `CreateAuditLogs` (20171018185609) to create the column
directly as `transaction_key`. On fresh databases the later `RenameTransactionToTransactionKey` then
tries to rename a column that no longer exists.

## Reproduction

Drop the `audit_logs` table (or use a fresh DB) and run:

bin/cake migrations migrate -p AuditStash

## Fix

Guard the rename with `hasColumn()` so the migration is a no-op on fresh installs but still works for
databases created before PR #39.
