### PR TITLE
Revert retroactive schema edit to CreateAuditLogs

### DIFF
--- a/config/Migrations/20171018185609_CreateAuditLogs.php
+++ b/config/Migrations/20171018185609_CreateAuditLogs.php
@@ -22,7 +22,7 @@ class CreateAuditLogs extends BaseMigration
                 'signed' => false,
             ])
             ->addPrimaryKey(['id'])
-            ->addColumn('transaction_key', 'binaryuuid', [
+            ->addColumn('transaction', 'binaryuuid', [
                 'default' => null,
                 'limit' => null,
                 'null' => false,
@@ -78,7 +78,7 @@ class CreateAuditLogs extends BaseMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addIndex(['transaction_key'])
+            ->addIndex(['transaction'])
             ->addIndex(['type'])
             ->addIndex(['primary_key'])
             ->addIndex(['display_value'])


### PR DESCRIPTION
## Summary

PR #39 changed the `transaction` column to `transaction_key` in two places:

1. Retroactively edited the original `CreateAuditLogs` migration (20171018185609) to create the column as `transaction_key` directly.
2. Added a new `RenameTransactionToTransactionKey` migration (20260416120000) to rename the column on existing installs.

That combination causes a schema divergence:

- **Existing installs:** ran the old `CreateAuditLogs` (with `transaction`), then run the rename migration — ends up with `transaction_key`. OK.
- **Fresh installs:** run the edited `CreateAuditLogs` (already `transaction_key`), then the rename migration fails because there is no `transaction` column to rename.

This was reported in #40, which patched around it by making the rename migration idempotent with a `hasColumn()` guard. That fixes the symptom but leaves the retroactively-edited migration in place, which is generally an anti-pattern — shipped migrations should not change.

## Fix

Restore `CreateAuditLogs` to its original shipped form (`transaction` column + index). The `RenameTransactionToTransactionKey` migration is now the single source of truth for the rename, working on both fresh and existing installs without any conditional logic.

Closes #40 (alternative approach).