### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Admin/AuditLogs/revert_preview.php
+++ b/templates/Admin/AuditLogs/revert_preview.php
@@ -6,6 +6,7 @@
  * @var array $targetState
  * @var array $diff
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <div class="auditLogs revert content">
     <div class="d-flex justify-content-between align-items-center mb-4">
@@ -44,7 +45,10 @@
             <?= __('No differences found. Record is already in this state.') ?>
         </div>
     <?php } else { ?>
-        <?= $this->Form->create(null, ['url' => ['action' => 'revert', $auditLog->id]]) ?>
+        <?= $this->Form->create(null, [
+            'url' => ['action' => 'revert', $auditLog->id],
+            'data-confirm-message' => __('Are you sure you want to revert the selected fields?'),
+        ]) ?>
 
         <div class="card">
             <div class="card-header">
@@ -91,7 +95,6 @@
                 <div>
                     <?= $this->Form->button(__('Revert Selected'), [
                         'class' => 'btn btn-primary',
-                        'confirm' => __('Are you sure you want to revert the selected fields?'),
                     ]) ?>
                 </div>
             </div>
@@ -101,7 +104,7 @@
     <?php } ?>
 </div>
 
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 document.addEventListener('DOMContentLoaded', function() {
     const checkboxes = document.querySelectorAll('input[name="fields[]"]');
     const btnSelectAll = document.getElementById('btn-select-all');

--- a/templates/layout/audit_stash.php
+++ b/templates/layout/audit_stash.php
@@ -18,6 +18,7 @@ $action = $this->getRequest()->getParam('action');
 $plugin = $this->getRequest()->getParam('plugin');
 $prefix = $this->getRequest()->getParam('prefix');
 $isIndex = $controller === 'AuditLogs' && $action === 'index';
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -379,7 +380,7 @@ $isIndex = $controller === 'AuditLogs' && $action === 'index';
     <!-- Flatpickr Date Picker -->
     <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 
-    <script>
+    <script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
     document.addEventListener('DOMContentLoaded', function() {
         // Initialize tooltips
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
@@ -395,10 +396,10 @@ $isIndex = $controller === 'AuditLogs' && $action === 'index';
             });
         });
 
-        // Form confirmation
-        document.querySelectorAll('form[data-confirm]').forEach(function(form) {
+        // Confirmation dialogs for postButton forms (CSP-safe replacement for postLink + confirm)
+        document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
             form.addEventListener('submit', function(e) {
-                if (!confirm(form.dataset.confirm)) {
+                if (!confirm(form.dataset.confirmMessage)) {
                     e.preventDefault();
                 }
             });


### PR DESCRIPTION
## Summary

- Add nonce attribute to 2 inline `<script>` blocks (layout + `revert_preview`).
- Move the `Form->button('confirm' => ...)` on the revert form to `data-confirm-message` on the `Form->create(...)` call so the delegated submit listener in the layout handles confirmation.
- Update the layout's existing delegated submit listener to hook `form[data-confirm-message]` (the postButton-compatible hook) instead of the legacy `form[data-confirm]`.

## Motivation

Under a strict Content-Security-Policy with `script-src 'self' 'nonce-...'`, inline `<script>` blocks without `nonce` and inline event handlers (`onclick=`, etc.) are blocked by the browser. Per the CSP spec, the `nonce` keyword applies ONLY to inline `<script>` / `<style>` blocks — not to event-handler attributes. `Form->button(..., ['confirm' => '...'])` emits an `onclick="..."` attribute and is therefore unsafe under strict CSP.

## Changes

- Add `nonce` attribute to 2 inline `<script>` blocks (layout `audit_stash.php` and `Admin/AuditLogs/revert_preview.php`).
- Drop `confirm` option from `Form->button` on the revert form; move the confirmation string to `data-confirm-message` on `Form->create(...)` so the layout delegate handles it.
- Switch the delegate selector from `form[data-confirm]` to `form[data-confirm-message]` to align with the postButton-based playbook (no templates referenced the old selector).

## Host app nonce setup

Apps that want to benefit need to set a `cspNonce` request attribute in a middleware, e.g.:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without `nonce` — apps on permissive CSP continue to work unchanged.

## Before / after

```diff
- <?= $this->Form->create(null, ['url' => ['action' => 'revert', $auditLog->id]]) ?>
+ <?= $this->Form->create(null, [
+     'url' => ['action' => 'revert', $auditLog->id],
+     'data-confirm-message' => __('Are you sure you want to revert the selected fields?'),
+ ]) ?>
...
- <?= $this->Form->button(__('Revert Selected'), [
-     'class' => 'btn btn-primary',
-     'confirm' => __('Are you sure you want to revert the selected fields?'),
- ]) ?>
+ <?= $this->Form->button(__('Revert Selected'), [
+     'class' => 'btn btn-primary',
+ ]) ?>
```
