### PR TITLE
Capture audit event timestamps with microsecond precision

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,37 @@ This means you don't need to change any configuration - it just works.
 
 **Note:** This requires MySQL 5.7.8+, MariaDB 10.2.7+, or PostgreSQL 9.2+. SQLite does not support native JSON columns.
 
+### Sub-Second Timestamp Precision
+
+Audit events are captured with microsecond precision (ISO 8601 with timezone offset, e.g.
+`2026-04-27T12:34:56.123456+00:00`), but the bundled migration creates the `created` column as a plain
+`DATETIME`, which MySQL stores at second precision. To actually persist the extra precision, copy the
+migration to your app and widen the column:
+
+```bash
+cp vendor/dereuromark/cakephp-audit-stash/config/Migrations/20171018185609_CreateAuditLogs.php config/Migrations/
+```
+
+Then change the `created` column to use a fractional seconds precision (`3` for milliseconds, `6` for
+microseconds):
+
+```php
+->addColumn('created', 'datetime', [
+    'default' => null,
+    'null' => false,
+    'precision' => 6,
+])
+```
+
+Notes:
+
+- PostgreSQL's `TIMESTAMP` already stores microseconds, so no migration change is needed.
+- SQLite stores datetimes as text and preserves whatever precision is written.
+- Elasticsearch's `date` mapping accepts the extended ISO string but truncates to milliseconds; use
+  `date_nanos` if you need full microsecond precision in the index.
+- If you want to access the timestamp as a `DateTime` object (e.g. in a custom persister) without
+  re-parsing the string, use `BaseEvent::getTimestampObject()`.
+
 ### UUID Primary Keys
 
 The default migration creates the `primary_key` column as an integer. If your application uses UUID primary keys,

--- a/src/Event/BaseEvent.php
+++ b/src/Event/BaseEvent.php
@@ -6,7 +6,7 @@ namespace AuditStash\Event;
 
 use AuditStash\EventInterface;
 use Cake\Datasource\EntityInterface;
-use DateTime;
+use Cake\I18n\DateTime;
 use ReturnTypeWillChange;
 
 /**
@@ -57,7 +57,7 @@ abstract class BaseEvent implements EventInterface
         $this->source = $source;
         $this->changed = $changed;
         $this->original = $original;
-        $this->timestamp = (new DateTime())->format(DateTime::ATOM);
+        $this->timestamp = (new DateTime())->format('Y-m-d\TH:i:s.uP');
         $this->entity = $entity;
         $this->displayValue = $displayValue;
     }

--- a/src/Event/BaseEventTrait.php
+++ b/src/Event/BaseEventTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AuditStash\Event;
 
 use Cake\Datasource\EntityInterface;
+use Cake\I18n\DateTime;
 
 /**
  * Implements most of the methods of the EventInterface.
@@ -126,11 +127,28 @@ trait BaseEventTrait
     /**
      * Returns the time string in which this change happened.
      *
+     * The string is ISO 8601 with microsecond precision and timezone offset
+     * (e.g. `2026-04-27T12:34:56.123456+00:00`).
+     *
      * @return string
      */
     public function getTimestamp(): string
     {
         return $this->timestamp;
+    }
+
+    /**
+     * Returns the time at which this change happened as a DateTime object,
+     * preserving the microsecond precision captured at event creation.
+     *
+     * Persisters can use this to skip the parse round-trip from the
+     * timestamp string.
+     *
+     * @return \Cake\I18n\DateTime
+     */
+    public function getTimestampObject(): DateTime
+    {
+        return new DateTime($this->timestamp);
     }
 
     /**

--- a/tests/TestCase/Event/TimestampPrecisionTest.php
+++ b/tests/TestCase/Event/TimestampPrecisionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\Test\TestCase\Event;
+
+use AuditStash\Event\AuditCreateEvent;
+use Cake\I18n\DateTime;
+use Cake\ORM\Entity;
+use Cake\TestSuite\TestCase;
+
+class TimestampPrecisionTest extends TestCase
+{
+    /**
+     * The timestamp string returned from getTimestamp() must carry
+     * sub-second precision so persisters can keep it.
+     */
+    public function testGetTimestampCarriesSubSecondPrecision(): void
+    {
+        $event = new AuditCreateEvent('123', 50, 'articles', ['title' => 'foo'], null, new Entity());
+
+        $timestamp = $event->getTimestamp();
+
+        $this->assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}[+-]\d{2}:\d{2}$/',
+            $timestamp,
+            'Timestamp should be ISO 8601 with microsecond precision and timezone offset.',
+        );
+    }
+
+    /**
+     * Round-tripping the timestamp string through Cake\I18n\DateTime
+     * (as ExtractionTrait does) must preserve the microsecond component.
+     */
+    public function testTimestampRoundTripPreservesMicroseconds(): void
+    {
+        $event = new AuditCreateEvent('123', 50, 'articles', ['title' => 'foo'], null, new Entity());
+
+        $parsed = new DateTime($event->getTimestamp());
+
+        $this->assertSame(
+            $event->getTimestamp(),
+            $parsed->format('Y-m-d\TH:i:s.uP'),
+            'Parsing the timestamp string should yield an equal DateTime when re-formatted with microseconds.',
+        );
+    }
+
+    /**
+     * BaseEvent exposes the timestamp as a Cake\I18n\DateTime so persisters
+     * can avoid the parse round-trip and keep microsecond precision.
+     */
+    public function testGetTimestampObjectReturnsCakeDateTime(): void
+    {
+        $event = new AuditCreateEvent('123', 50, 'articles', ['title' => 'foo'], null, new Entity());
+
+        $object = $event->getTimestampObject();
+
+        $this->assertInstanceOf(DateTime::class, $object);
+        $this->assertSame($event->getTimestamp(), $object->format('Y-m-d\TH:i:s.uP'));
+    }
+}


### PR DESCRIPTION
Closes #43.

## Summary

`BaseEvent::__construct()` formatted the timestamp with `DateTime::ATOM`, which truncates at seconds. Persisters that re-parse `getTimestamp()` into a `DateTime` therefore lost any sub-second resolution before persistence, even on backends (Elasticsearch, MySQL `DATETIME(6)`, Postgres) that can store it.

This PR:

- Switches the format string to `Y-m-d\TH:i:s.uP` so the captured ISO 8601 string carries microseconds and a timezone offset.
- Adds `BaseEventTrait::getTimestampObject(): \Cake\I18n\DateTime`, which persisters can prefer to skip the parse round trip in `ExtractionTrait`.
- Switches the internal `DateTime` import to `Cake\I18n\DateTime` so the captured time honors the application's timezone configuration.

## BC

Intentionally non-breaking, as a counter-proposal to changing `EventInterface::getTimestamp()`'s return type:

- `getTimestamp()` still returns `string` and still parses cleanly into both `\DateTime` and `\Cake\I18n\DateTime`.
- The `$timestamp` property type stays `string`, so previously serialized events (queue payloads, on-disk caches) round-trip unchanged.
- `EventInterface` is untouched; custom implementors keep working. `getTimestampObject()` lives on `BaseEventTrait` only — persisters that want it can use `method_exists()` or accept `BaseEvent`.
- JSON output via `basicSerialize()` keeps the same `@timestamp` key with a string value.

## Caveats for users

- MySQL stores `DATETIME` at second precision unless the column is declared `DATETIME(3)` or `DATETIME(6)`; existing installs need a migration on their side to actually persist the extra precision. Postgres `TIMESTAMP` already keeps microseconds. Elasticsearch's `date` mapping accepts the extended form natively.
- Consciously **not** touching the bundled `CreateAuditLogs` migration — see the recent revert on that file. A follow-up that opts new installs into `DATETIME(6)` can be a separate, opt-in PR.

## Why this shape over the issue's proposal

The issue suggests changing `getTimestamp()` to return a `DateTime`. That would break every implementor of `EventInterface` and every persister that reads the string. Storing microseconds inside the existing string buys ~all the value (persisters get the precision automatically through the existing `new DateTime($event->getTimestamp())` call) at zero BC cost, with the object accessor as an opt-in fast path.
