### PR TITLE
Add AuditStash.accessCheck Closure gate (opt-in defense-in-depth)

### DIFF
--- a/docs/viewer.md
+++ b/docs/viewer.md
@@ -270,6 +270,22 @@ The audit log viewer provides:
 
 The audit log viewer is in the Admin prefix by default, which provides a layer of security. However, you should ensure your Admin prefix is properly secured with authentication/authorization. Here are some additional approaches:
 
+### Option 0 (recommended): `AuditStash.accessCheck`
+
+Set a `Closure` that receives the current request and returns literal `true` to grant access. Anything else (returns `false`, returns a truthy non-bool, throws) yields a `403`. Defense-in-depth on top of the host's existing admin gating; particularly relevant here because audit logs commonly contain sensitive who-did-what records (PII, IP addresses, what fields changed).
+
+```php
+use Cake\Core\Configure;
+use Cake\Http\ServerRequest;
+
+Configure::write('AuditStash.accessCheck', function (ServerRequest $request): bool {
+    $identity = $request->getAttribute('identity');
+    return $identity !== null && $identity->role === 'super_admin';
+});
+```
+
+Unset = no-op (host auth alone applies). The gate is checked in `beforeFilter` and calls `Authorization::skipAuthorization()` when the cakephp/authorization component is loaded, so the policy layer doesn't double-reject. Closures that throw `ForbiddenException` are passed through; other throwables are logged and converted to a generic `403`.
+
 ### Option 1: Use Authorization Plugin
 
 ```php

--- a/src/Controller/Admin/AuditLogsController.php
+++ b/src/Controller/Admin/AuditLogsController.php
@@ -9,9 +9,14 @@ use AuditStash\AuditLogType;
 use AuditStash\Service\RevertService;
 use AuditStash\Service\StateReconstructorService;
 use Cake\Core\Configure;
+use Cake\Event\EventInterface;
+use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Response;
+use Cake\Log\Log;
+use Closure;
 use InvalidArgumentException;
 use RuntimeException;
+use Throwable;
 
 /**
  * AuditLogs Controller
@@ -51,6 +56,56 @@ class AuditLogsController extends AppController
         } else {
             // Use custom layout
             $this->viewBuilder()->setLayout($adminLayout);
+        }
+    }
+
+    /**
+     * Optional defense-in-depth access gate.
+     *
+     * Audit logs commonly contain sensitive who-did-what records (PII, IP
+     * addresses, what fields were changed). Set `AuditStash.accessCheck` to
+     * a Closure that receives the current request and returns literal `true`
+     * to grant access; anything else (returns false, returns a truthy
+     * non-bool, throws) yields a 403.
+     *
+     * Unset = no-op (host AppController auth alone applies).
+     *
+     * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event
+     *
+     * @throws \Cake\Http\Exception\ForbiddenException When the configured Closure rejects the request.
+     *
+     * @return void
+     */
+    public function beforeFilter(EventInterface $event): void
+    {
+        parent::beforeFilter($event);
+
+        $check = Configure::read('AuditStash.accessCheck');
+        if ($check === null) {
+            return;
+        }
+        if (!($check instanceof Closure)) {
+            throw new ForbiddenException('AuditStash.accessCheck must be a Closure');
+        }
+
+        // Coexist with cakephp/authorization: the gate IS the authorization
+        // decision, so silence the policy check.
+        if ($this->components()->has('Authorization') && method_exists($this->components()->get('Authorization'), 'skipAuthorization')) {
+            $this->components()->get('Authorization')->skipAuthorization();
+        }
+
+        try {
+            $allowed = $check($this->request) === true;
+        } catch (ForbiddenException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            Log::warning(sprintf('AuditStash.accessCheck threw %s: %s', $e::class, $e->getMessage()));
+
+            throw new ForbiddenException('AuditStash admin access denied');
+        }
+
+        if (!$allowed) {
+            throw new ForbiddenException('AuditStash admin access denied');
         }
     }
 

--- a/tests/TestCase/Controller/AuditLogsControllerTest.php
+++ b/tests/TestCase/Controller/AuditLogsControllerTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace AuditStash\Test\TestCase\Controller;
 
+use Cake\Core\Configure;
+use Cake\Http\Exception\ForbiddenException;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 
 /**
  * AuditStash\Controller\Admin\AuditLogsController Test Case
@@ -26,6 +29,97 @@ class AuditLogsControllerTest extends TestCase
         'plugin.AuditStash.AuditLogs',
         'plugin.AuditStash.Articles',
     ];
+
+    /**
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        Configure::delete('AuditStash.accessCheck');
+        parent::tearDown();
+    }
+
+    public function testAccessCheckUnsetIsNoOp(): void
+    {
+        $this->get(['prefix' => 'Admin', 'plugin' => 'AuditStash', 'controller' => 'AuditLogs', 'action' => 'index']);
+
+        $this->assertResponseOk();
+    }
+
+    public function testAccessCheckNonClosureRejects(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        Configure::write('AuditStash.accessCheck', 'not a closure');
+
+        $this->expectException(ForbiddenException::class);
+        $this->get(['prefix' => 'Admin', 'plugin' => 'AuditStash', 'controller' => 'AuditLogs', 'action' => 'index']);
+    }
+
+    public function testAccessCheckClosureFalseRejects(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        Configure::write('AuditStash.accessCheck', fn () => false);
+
+        $this->expectException(ForbiddenException::class);
+        $this->get(['prefix' => 'Admin', 'plugin' => 'AuditStash', 'controller' => 'AuditLogs', 'action' => 'index']);
+    }
+
+    public function testAccessCheckRequiresStrictTrue(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        Configure::write('AuditStash.accessCheck', fn () => 1);
+
+        $this->expectException(ForbiddenException::class);
+        $this->get(['prefix' => 'Admin', 'plugin' => 'AuditStash', 'controller' => 'AuditLogs', 'action' => 'index']);
+    }
+
+    public function testAccessCheckClosureTrueAllows(): void
+    {
+        Configure::write('AuditStash.accessCheck', fn () => true);
+
+        $this->get(['prefix' => 'Admin', 'plugin' => 'AuditStash', 'controller' => 'AuditLogs', 'action' => 'index']);
+
+        $this->assertResponseOk();
+    }
+
+    public function testAccessCheckThrowingYields403(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        Configure::write('AuditStash.accessCheck', function (): bool {
+            throw new RuntimeException('oops');
+        });
+
+        $this->expectException(ForbiddenException::class);
+        $this->get(['prefix' => 'Admin', 'plugin' => 'AuditStash', 'controller' => 'AuditLogs', 'action' => 'index']);
+    }
+
+    public function testAccessCheckExplicitForbiddenIsRespected(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        Configure::write('AuditStash.accessCheck', function (): bool {
+            throw new ForbiddenException('custom denial reason');
+        });
+
+        $this->expectException(ForbiddenException::class);
+        $this->expectExceptionMessage('custom denial reason');
+        $this->get(['prefix' => 'Admin', 'plugin' => 'AuditStash', 'controller' => 'AuditLogs', 'action' => 'index']);
+    }
+
+    public function testAccessCheckReceivesRequest(): void
+    {
+        $received = null;
+        Configure::write('AuditStash.accessCheck', function ($request) use (&$received): bool {
+            $received = $request;
+
+            return true;
+        });
+
+        $this->get(['prefix' => 'Admin', 'plugin' => 'AuditStash', 'controller' => 'AuditLogs', 'action' => 'index']);
+
+        $this->assertResponseOk();
+        $this->assertNotNull($received);
+        $this->assertStringContainsString('audit', $received->getPath());
+    }
 
     /**
      * Test index method


### PR DESCRIPTION
## Summary

Adds an optional `AuditStash.accessCheck` Closure gate to the `/admin/audit-logs` viewer. Defense-in-depth on top of host `AppController` auth; unset = no-op (current behavior preserved). **Non-breaking.**

## Why

Audit logs commonly contain sensitive who-did-what records — PII, IP addresses, before/after field values for every change. The existing `docs/viewer.md` already recommends additional gating (Options 1-3 of "Additional Security"), but those require modifying the host `AppController`. This PR adds a self-contained config knob: one `Configure::write` and the plugin handles it.

## Behavior

- **Unset** (default) → no-op. Host auth alone applies. **No breaking change.**
- **Non-`Closure` value** → `403`. Misconfigured key fails closed.
- **`Closure` returns literal `true`** → request proceeds.
- **`Closure` returns `false` / truthy non-bool** → `403`.
- **`Closure` throws `ForbiddenException`** → respected as-is (caller can short-circuit with their own message).
- **`Closure` throws any other `Throwable`** → logged via `Cake\Log\Log` and converted to a generic `403`.

Calls `Authorization::skipAuthorization()` when the cakephp/authorization component is loaded.

## Example

```php
use Cake\Core\Configure;
use Cake\Http\ServerRequest;

Configure::write('AuditStash.accessCheck', function (ServerRequest $request): bool {
    $identity = $request->getAttribute('identity');
    return $identity !== null && $identity->role === 'super_admin';
});
```

## Tests

8 new cases in `AuditLogsControllerTest` cover all branches. All 283 existing tests still pass.

## Checklist

- [x] phpunit (283/283)
- [x] phpcs clean
- [x] phpstan clean
- [x] Docs updated (`docs/viewer.md` recommends the new option above the existing three)
