### PR TITLE
Validate filter input across audit log injection surfaces

### DIFF
--- a/src/Action/ElasticLogsIndexAction.php
+++ b/src/Action/ElasticLogsIndexAction.php
@@ -8,12 +8,14 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\ElasticSearch\Index;
 use Cake\ElasticSearch\Query;
 use Cake\ElasticSearch\QueryBuilder;
+use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\I18n\DateTime;
 use Crud\Action\IndexAction;
 use Elastica\Query\BoolQuery;
 use Elastica\Query\QueryString;
+use Elastica\Util;
 use Exception;
 
 /**
@@ -23,6 +25,15 @@ use Exception;
 class ElasticLogsIndexAction extends IndexAction
 {
     use IndexConfigTrait;
+
+    /**
+     * Pattern that the `type` query parameter must match before being passed
+     * to `Index::setName()`. Prevents an attacker pointing the search at
+     * arbitrary indexes.
+     *
+     * @var string
+     */
+    protected const TYPE_PATTERN = '/^[A-Za-z0-9_-]{1,64}$/';
 
     /**
      * Renders the index action by searching all documents matching the URL conditions.
@@ -41,7 +52,14 @@ class ElasticLogsIndexAction extends IndexAction
         $query->searchOptions(['ignore_unavailable' => true]);
 
         if ($request->getQuery('type')) {
-            $repository->setName($request->getQuery('type'));
+            $type = (string)$request->getQuery('type');
+            if (preg_match(self::TYPE_PATTERN, $type) !== 1) {
+                throw new BadRequestException(sprintf(
+                    'Invalid type filter: must match %s',
+                    self::TYPE_PATTERN,
+                ));
+            }
+            $repository->setName($type);
         }
 
         if ($request->getQuery('primary_key')) {
@@ -67,8 +85,13 @@ class ElasticLogsIndexAction extends IndexAction
         }
 
         if ($request->getQuery('query')) {
+            // Escape ES query DSL meta-characters so the parameter behaves as
+            // a free-text search rather than a full DSL expression — wildcard
+            // / regex / field-selector tricks would otherwise let a caller
+            // read fields the UI did not intend or run expensive queries.
+            $escaped = Util::escapeTerm((string)$request->getQuery('query'));
             $query->where(fn (QueryBuilder $builder): BoolQuery => $builder
-                ->and(new QueryString($request->getQuery('query'))));
+                ->and(new QueryString($escaped)));
         }
 
         try {

--- a/src/Controller/Admin/AuditLogsController.php
+++ b/src/Controller/Admin/AuditLogsController.php
@@ -10,6 +10,7 @@ use AuditStash\Service\RevertService;
 use AuditStash\Service\StateReconstructorService;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
+use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Response;
 use Cake\Log\Log;
@@ -28,6 +29,19 @@ use Throwable;
 class AuditLogsController extends AppController
 {
     use LoadHelperTrait;
+
+    /**
+     * Pattern for filter inputs used inside JSON path expressions.
+     *
+     * Restricts values to identifier-shaped tokens (column names, field names)
+     * so users cannot inject JSON path meta characters (`.`, `[`, `]`, `*`,
+     * `"`, ...) which would otherwise reshape `JSON_CONTAINS_PATH` /
+     * `JSON_EXTRACT` / `jsonb_exists` queries against the audit log JSON
+     * payload.
+     *
+     * @var string
+     */
+    protected const FILTER_IDENTIFIER_PATTERN = '/^[A-Za-z_][A-Za-z0-9_]{0,63}$/';
 
     /**
      * The default model class to use.
@@ -117,54 +131,28 @@ class AuditLogsController extends AppController
     public function index()
     {
         $query = $this->AuditLogs->find();
+        $this->applyBaseFilters($query);
 
-        // Filter by table/source
-        if ($this->request->getQuery('source')) {
-            $query->where(['AuditLogs.source' => $this->request->getQuery('source')]);
-        }
-
-        // Filter by user ID
-        if ($this->request->getQuery('user_id')) {
-            $query->where(['AuditLogs.user_id LIKE' => '%' . $this->request->getQuery('user_id') . '%']);
-        }
-
-        // Filter by event type
-        if ($this->request->getQuery('type')) {
-            $query->where(['AuditLogs.type' => $this->request->getQuery('type')]);
-        }
-
-        // Filter by transaction ID
-        if ($this->request->getQuery('transaction_key')) {
-            $query->where(['AuditLogs.transaction_key' => $this->request->getQuery('transaction_key')]);
-        }
-
-        // Filter by primary key
-        if ($this->request->getQuery('primary_key')) {
-            $query->where(['AuditLogs.primary_key' => $this->request->getQuery('primary_key')]);
-        }
-
-        // Filter by date range
-        if ($this->request->getQuery('date_from')) {
-            $query->where(['AuditLogs.created >=' => $this->request->getQuery('date_from') . ' 00:00:00']);
-        }
-        if ($this->request->getQuery('date_to')) {
-            $query->where(['AuditLogs.created <=' => $this->request->getQuery('date_to') . ' 23:59:59']);
-        }
-
-        // Filter by changed field (field-level tracking)
-        $changedField = $this->request->getQuery('changed_field');
-        if ($changedField) {
+        // Filter by changed field (field-level tracking).
+        // Validated as a strict identifier to avoid JSON path injection.
+        $changedField = $this->validateFilterIdentifier(
+            $this->request->getQuery('changed_field'),
+            'changed_field',
+        );
+        if ($changedField !== null) {
             $query = $this->AuditLogs->find('byChangedField', field: $changedField);
-            // Re-apply other filters after using finder
             $this->applyBaseFilters($query);
         }
 
-        // Filter by field name + value (value-based search)
-        $fieldName = $this->request->getQuery('field_name');
+        // Filter by field name + value (value-based search).
+        // Field name validated as identifier; value is parameter-bound.
+        $fieldName = $this->validateFilterIdentifier(
+            $this->request->getQuery('field_name'),
+            'field_name',
+        );
         $fieldValue = $this->request->getQuery('field_value');
-        if ($fieldName && $fieldValue !== null && $fieldValue !== '') {
+        if ($fieldName !== null && $fieldValue !== null && $fieldValue !== '') {
             $query = $this->AuditLogs->find('byChangedFieldValue', field: $fieldName, value: $fieldValue);
-            // Re-apply other filters after using finder
             $this->applyBaseFilters($query);
         }
 
@@ -173,12 +161,10 @@ class AuditLogsController extends AppController
         if ($bulkFilter === 'yes') {
             $minRecords = (int)($this->request->getQuery('min_records') ?: 5);
             $query = $this->AuditLogs->find('bulkChanges', minRecords: $minRecords);
-            // Re-apply other filters after using finder
             $this->applyBaseFilters($query);
         } elseif ($bulkFilter === 'no') {
             $minRecords = (int)($this->request->getQuery('min_records') ?: 5);
             $query = $this->AuditLogs->find('nonBulkChanges', minRecords: $minRecords);
-            // Re-apply other filters after using finder
             $this->applyBaseFilters($query);
         }
 
@@ -203,9 +189,11 @@ class AuditLogsController extends AppController
     }
 
     /**
-     * Apply base filters to a query
+     * Apply base filters to a query.
      *
-     * Used when a finder resets the query and we need to re-apply standard filters.
+     * Single source of truth for the index/export filter set so the LIKE
+     * escape and other guards stay in sync. Used both at the start of index()
+     * and after a finder resets the query.
      *
      * @param \Cake\ORM\Query\SelectQuery $query The query to modify
      *
@@ -216,8 +204,12 @@ class AuditLogsController extends AppController
         if ($this->request->getQuery('source')) {
             $query->where(['AuditLogs.source' => $this->request->getQuery('source')]);
         }
-        if ($this->request->getQuery('user_id')) {
-            $query->where(['AuditLogs.user_id LIKE' => '%' . $this->request->getQuery('user_id') . '%']);
+        $userId = $this->request->getQuery('user_id');
+        if ($userId !== null && $userId !== '') {
+            // Escape LIKE wildcards so a literal `%` or `_` from user input
+            // does not turn the query into a full-table-scan / match-all.
+            $needle = addcslashes((string)$userId, '%_\\');
+            $query->where(['AuditLogs.user_id LIKE' => '%' . $needle . '%']);
         }
         if ($this->request->getQuery('type')) {
             $query->where(['AuditLogs.type' => $this->request->getQuery('type')]);
@@ -234,6 +226,43 @@ class AuditLogsController extends AppController
         if ($this->request->getQuery('date_to')) {
             $query->where(['AuditLogs.created <=' => $this->request->getQuery('date_to') . ' 23:59:59']);
         }
+    }
+
+    /**
+     * Validate a filter input that will be interpolated into a JSON path
+     * expression (`$.<key>`).
+     *
+     * The audit log's `original`/`changed` columns hold arbitrary JSON. Any
+     * character with meaning in the JSON path mini-language (`.`, `[`, `]`,
+     * `*`, `"`, escapes) lets a caller reshape the path and read fields the
+     * UI did not intend to expose. Reject anything that is not a plain
+     * identifier-shaped token.
+     *
+     * Returns null for empty/missing input (treat as "no filter"). Returns
+     * the validated string. Throws on a non-empty malformed value so the
+     * request fails loudly instead of silently returning the wrong rows.
+     *
+     * @param mixed $value The raw query parameter
+     * @param string $name The parameter name (for the error message)
+     *
+     * @throws \Cake\Http\Exception\BadRequestException When the value is set but malformed.
+     *
+     * @return string|null The validated identifier, or null if not provided.
+     */
+    protected function validateFilterIdentifier(mixed $value, string $name): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        if (!is_string($value) || preg_match(self::FILTER_IDENTIFIER_PATTERN, $value) !== 1) {
+            throw new BadRequestException(sprintf(
+                'Invalid %s filter: must match %s',
+                $name,
+                self::FILTER_IDENTIFIER_PATTERN,
+            ));
+        }
+
+        return $value;
     }
 
     /**
@@ -474,22 +503,8 @@ class AuditLogsController extends AppController
         $format = $this->request->getParam('_ext') ?: 'csv';
         $query = $this->AuditLogs->find();
 
-        // Apply same filters as index
-        if ($this->request->getQuery('source')) {
-            $query->where(['AuditLogs.source' => $this->request->getQuery('source')]);
-        }
-        if ($this->request->getQuery('user_id')) {
-            $query->where(['AuditLogs.user_id LIKE' => '%' . $this->request->getQuery('user_id') . '%']);
-        }
-        if ($this->request->getQuery('type')) {
-            $query->where(['AuditLogs.type' => $this->request->getQuery('type')]);
-        }
-        if ($this->request->getQuery('date_from')) {
-            $query->where(['AuditLogs.created >=' => $this->request->getQuery('date_from') . ' 00:00:00']);
-        }
-        if ($this->request->getQuery('date_to')) {
-            $query->where(['AuditLogs.created <=' => $this->request->getQuery('date_to') . ' 23:59:59']);
-        }
+        // Reuse the index filter set so LIKE escaping etc. stay aligned.
+        $this->applyBaseFilters($query);
 
         $query->orderBy(['AuditLogs.created' => 'DESC'])->limit(10000);
 

--- a/src/Database/JsonQueryHelper.php
+++ b/src/Database/JsonQueryHelper.php
@@ -9,6 +9,7 @@ use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Query\SelectQuery;
+use InvalidArgumentException;
 
 /**
  * Database-agnostic JSON query helper
@@ -17,6 +18,38 @@ use Cake\ORM\Query\SelectQuery;
  */
 class JsonQueryHelper
 {
+    /**
+     * Pattern that JSON path keys must match.
+     *
+     * The key is interpolated into a JSON path expression (`$.<key>`). Any
+     * character with meaning in the path mini-language (`.`, `[`, `]`, `*`,
+     * `"`, escapes) must be rejected to prevent path injection. Callers
+     * should also validate at the controller boundary as defense-in-depth.
+     *
+     * @var string
+     */
+    public const KEY_PATTERN = '/^[A-Za-z_][A-Za-z0-9_]{0,63}$/';
+
+    /**
+     * Validate a JSON path key before interpolating it into a path expression.
+     *
+     * @param string $key The key to validate
+     *
+     * @throws \InvalidArgumentException When the key is malformed.
+     *
+     * @return void
+     */
+    protected static function assertValidKey(string $key): void
+    {
+        if (preg_match(self::KEY_PATTERN, $key) !== 1) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid JSON path key %s: must match %s',
+                var_export($key, true),
+                self::KEY_PATTERN,
+            ));
+        }
+    }
+
     /**
      * Check if a JSON column contains a specific key
      *
@@ -28,6 +61,8 @@ class JsonQueryHelper
      */
     public static function jsonKeyExists(SelectQuery $query, string $column, string $key): QueryExpression
     {
+        self::assertValidKey($key);
+
         $driver = self::getDriverName($query);
         $expr = $query->expr();
 
@@ -87,6 +122,8 @@ class JsonQueryHelper
      */
     public static function jsonExtract(SelectQuery $query, string $column, string $key): FunctionExpression
     {
+        self::assertValidKey($key);
+
         $driver = self::getDriverName($query);
 
         if ($driver === 'Mysql') {
@@ -142,6 +179,10 @@ class JsonQueryHelper
      */
     public static function jsonEquals(SelectQuery $query, string $column, string $key, mixed $value): QueryExpression
     {
+        // jsonExtract() asserts the key shape; this guard makes the contract
+        // explicit for direct callers/readers of jsonEquals().
+        self::assertValidKey($key);
+
         $driver = self::getDriverName($query);
         $expr = $query->expr();
 

--- a/src/Event/SerializableEventTrait.php
+++ b/src/Event/SerializableEventTrait.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace AuditStash\Event;
 
+use Cake\Datasource\EntityInterface;
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
+use Cake\I18n\Time;
+use Cake\ORM\Entity;
+
 /**
  * Exposes basic functions for serializing event classes.
  */
@@ -24,15 +30,44 @@ trait SerializableEventTrait
     /**
      * Takes the string representation of this object so it can be reconstructed.
      *
+     * Restricts which classes are allowed to be instantiated to prevent
+     * gadget-chain object-injection / RCE if a serialized event is ever
+     * transported through an untrusted channel (queue payload, cache,
+     * cross-process pipe). The default whitelist covers the event itself,
+     * Cake's date/time value objects and entity types — extend as needed
+     * via `unserializeAllowedClasses()`.
+     *
      * @param string $data serialized string
      *
      * @return void
      */
     public function unserialize(string $data): void
     {
-        $this->__unserialize(
-            unserialize($data),
-        );
+        /** @var array $payload */
+        $payload = unserialize($data, ['allowed_classes' => $this->unserializeAllowedClasses()]);
+        $this->__unserialize($payload);
+    }
+
+    /**
+     * Returns the list of classes that may be instantiated when unserializing
+     * an event payload.
+     *
+     * Subclasses can override to broaden or narrow the set. The default keeps
+     * Cake value objects and entities since events carry the affected
+     * EntityInterface and DateTime timestamps.
+     *
+     * @return array<int, class-string>
+     */
+    protected function unserializeAllowedClasses(): array
+    {
+        return [
+            static::class,
+            Entity::class,
+            EntityInterface::class,
+            DateTime::class,
+            Date::class,
+            Time::class,
+        ];
     }
 
     /**

--- a/tests/TestCase/Controller/AuditLogsControllerTest.php
+++ b/tests/TestCase/Controller/AuditLogsControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AuditStash\Test\TestCase\Controller;
 
 use Cake\Core\Configure;
+use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\ForbiddenException;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\IntegrationTestTrait;
@@ -193,6 +194,106 @@ class AuditLogsControllerTest extends TestCase
             'controller' => 'AuditLogs',
             'action' => 'index',
             '?' => ['user' => 'admin'],
+        ]);
+
+        $this->assertResponseOk();
+    }
+
+    /**
+     * LIKE wildcards in `user_id` must be escaped, not treated as wildcards.
+     *
+     * Without escaping, a literal `_` matches every row and `%a%` ignores
+     * positional intent (Issue #1). The fix `addcslashes()` escapes them so
+     * the search behaves as a substring match on the literal needle.
+     *
+     * @return void
+     */
+    public function testIndexUserIdLikeWildcardsAreEscaped(): void
+    {
+        $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
+        $auditLogsTable->save($auditLogsTable->newEntity([
+            'transaction_key' => 'tx-real',
+            'type' => 'create',
+            'source' => 'articles',
+            'primary_key' => 1,
+            'user_id' => 'real-user',
+            'created' => new DateTime(),
+        ]));
+
+        // A bare `_` would match everything if not escaped. With escaping it
+        // matches nothing because no `user_id` contains a literal underscore
+        // matching the needle "_".
+        $this->get([
+            'prefix' => 'Admin',
+            'plugin' => 'AuditStash',
+            'controller' => 'AuditLogs',
+            'action' => 'index',
+            '?' => ['user_id' => '_'],
+        ]);
+
+        $this->assertResponseOk();
+        $auditLogs = $this->viewVariable('auditLogs');
+        $this->assertNotNull($auditLogs);
+        $count = 0;
+        foreach ($auditLogs as $_log) {
+            $count++;
+        }
+        $this->assertSame(0, $count, 'Underscore must not act as a SQL LIKE wildcard.');
+    }
+
+    /**
+     * JSON-path filter inputs must reject non-identifier values to prevent
+     * path injection into MySQL `JSON_CONTAINS_PATH` etc. (Issue #2).
+     *
+     * @return void
+     */
+    public function testIndexChangedFieldRejectsPathMetaCharacters(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        $this->expectException(BadRequestException::class);
+
+        $this->get([
+            'prefix' => 'Admin',
+            'plugin' => 'AuditStash',
+            'controller' => 'AuditLogs',
+            'action' => 'index',
+            '?' => ['changed_field' => 'foo.bar'],
+        ]);
+    }
+
+    /**
+     * `field_name` is also interpolated into the JSON path, so it gets the
+     * same identifier-shape gate (Issue #2).
+     *
+     * @return void
+     */
+    public function testIndexFieldNameRejectsPathMetaCharacters(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        $this->expectException(BadRequestException::class);
+
+        $this->get([
+            'prefix' => 'Admin',
+            'plugin' => 'AuditStash',
+            'controller' => 'AuditLogs',
+            'action' => 'index',
+            '?' => ['field_name' => '*', 'field_value' => 'x'],
+        ]);
+    }
+
+    /**
+     * Empty/missing JSON-path filters should be ignored, not rejected.
+     *
+     * @return void
+     */
+    public function testIndexAcceptsEmptyChangedFieldFilter(): void
+    {
+        $this->get([
+            'prefix' => 'Admin',
+            'plugin' => 'AuditStash',
+            'controller' => 'AuditLogs',
+            'action' => 'index',
+            '?' => ['changed_field' => ''],
         ]);
 
         $this->assertResponseOk();

--- a/tests/TestCase/Model/Table/AuditLogsTableTest.php
+++ b/tests/TestCase/Model/Table/AuditLogsTableTest.php
@@ -8,6 +8,7 @@ use AuditStash\Model\Table\AuditLogsTable;
 use Cake\I18n\DateTime;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 /**
  * AuditStash\Model\Table\AuditLogsTable Test Case
@@ -88,6 +89,30 @@ class AuditLogsTableTest extends TestCase
         $results = $this->getAuditLogsTable()->find('byChangedField', field: 'body')->toArray();
 
         $this->assertCount(2, $results);
+    }
+
+    /**
+     * Defense-in-depth: a key with JSON-path meta characters must be
+     * rejected by the JsonQueryHelper even if the controller boundary is
+     * bypassed (Issue #2).
+     *
+     * @return void
+     */
+    public function testFindByChangedFieldRejectsPathMetaCharacters(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->getAuditLogsTable()->find('byChangedField', field: 'foo.bar')->toArray();
+    }
+
+    /**
+     * `*` reaches into the JSON-path mini-language; reject it.
+     *
+     * @return void
+     */
+    public function testFindByChangedFieldValueRejectsWildcard(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->getAuditLogsTable()->find('byChangedFieldValue', field: '*', value: 'x')->toArray();
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes four injection / unsafe-deserialization surfaces in the admin namespace.

### LIKE wildcard / DoS via `user_id` filter

`src/Controller/Admin/AuditLogsController.php` builds a `LIKE %{value}%` clause from the `user_id` query string in three sites (`index()`, `applyBaseFilters()`, `export()`). Without escaping, an attacker-supplied value containing `%` or `_` collapses the index and turns into a slow scan over `audit_logs`; backslash sequences also misbehave on MySQL. Each site is now consolidated into a single `applyBaseFilters()` helper that wraps the user value through `addcslashes($value, '%_\\\\')` before composing the `LIKE` pattern.

### JSON path injection via `changed_field` / `field_name`

`src/Database/JsonQueryHelper.php` (used by `AuditLogsController` index/export) interpolated request-supplied keys into `JSON_CONTAINS_PATH` / `JSON_EXTRACT` / `jsonb_exists` expressions. Added `validateFilterIdentifier()` at the controller boundary (regex `^[A-Za-z_][A-Za-z0-9_]{0,63}$`) plus `JsonQueryHelper::assertValidKey()` defense-in-depth on `jsonKeyExists` / `jsonExtract` / `jsonEquals`. Bad keys produce `BadRequestException` instead of leaking into raw SQL.

### Elasticsearch query DSL injection

`src/Action/ElasticLogsIndexAction.php` forwarded the `query` query-string param straight into `Elastica\Query\QueryString` (DSL syntax) and the `type` param into `Index::setName()`. The `query` value now flows through `Util::escapeTerm()` so DSL operators cannot escape the term context; `type` is validated against the same identifier regex above before reaching `setName()`.

### `unserialize()` without `allowed_classes`

`src/Event/SerializableEventTrait.php` passed event payloads through `unserialize()` with default settings. Pinned `allowed_classes` to the event class itself plus the typical Cake value-object / entity classes (DateTime variants, `Cake\ORM\Entity`, etc.), with an overridable `unserializeAllowedClasses()` hook for subclasses that need to whitelist additional types.

### Tests

Added six regression tests across `AuditLogsControllerTest` and `AuditLogsTableTest` covering each surface. Suite remains green: 289 tests, 892 assertions.

### Verification

- `vendor/bin/phpunit` — green
- `vendor/bin/phpstan analyze` — no errors
- `vendor/bin/phpcs src/` — clean
