### PR TITLE
Add custom action event support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,25 @@ configuration, verification, and anchoring strategies.
 
 See [Configuration Documentation](docs/configuration.md) for storage options.
 
+### Custom Action Events
+Beyond entity create/update/delete, log arbitrary actions like logins,
+exports, or permission grants:
+
+```php
+use AuditStash\Audit;
+
+Audit::log(
+    type: 'user.login',
+    source: 'Users',
+    primaryKey: $user->id,
+    data: ['ip' => $request->clientIp()],
+    meta: ['user_id' => $user->id, 'user_display' => $user->name],
+);
+```
+
+The `type` column accepts any string up to 64 chars. Custom events flow
+through the same persister, hash chain, and viewer as entity events.
+
 ## Documentation
 
 - **[Configuration](docs/configuration.md)** - Database and Elasticsearch setup, persister options

--- a/config/Migrations/20260502120000_WidenTypeColumn.php
+++ b/config/Migrations/20260502120000_WidenTypeColumn.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+/**
+ * Widen audit_logs.type from VARCHAR(7) to VARCHAR(64) so that custom
+ * action event types (e.g. "user.login", "report.exported") can be stored
+ * alongside the built-in create/update/delete/revert values.
+ */
+class WidenTypeColumn extends BaseMigration
+{
+    public function up(): void
+    {
+        $this->table('audit_logs')
+            ->changeColumn('type', 'string', [
+                'limit' => 64,
+                'null' => false,
+            ])
+            ->update();
+    }
+
+    public function down(): void
+    {
+        $this->table('audit_logs')
+            ->changeColumn('type', 'string', [
+                'limit' => 7,
+                'null' => false,
+            ])
+            ->update();
+    }
+}

--- a/src/Audit.php
+++ b/src/Audit.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash;
+
+use AuditStash\Event\AuditCustomEvent;
+use AuditStash\Persister\TablePersister;
+use Cake\Utility\Text;
+
+/**
+ * Static facade for emitting custom audit events that don't map to entity
+ * create/update/delete.
+ *
+ * ```
+ * use AuditStash\Audit;
+ *
+ * Audit::log('user.login', 'Users', $user->id, [
+ *     'ip' => $request->clientIp(),
+ *     'user_agent' => $request->getHeaderLine('User-Agent'),
+ * ], meta: [
+ *     'user_id' => $user->id,
+ *     'user_display' => $user->name,
+ * ]);
+ * ```
+ *
+ * The persister can be swapped via `Audit::setPersister()` for testing or to
+ * apply non-default config (e.g. hash chain enabled).
+ */
+class Audit
+{
+    protected static ?PersisterInterface $persister = null;
+
+    /**
+     * Persists a single custom audit event.
+     *
+     * @param string $type Event type identifier (e.g. "user.login"). Must fit
+     *   the audit_logs.type column (VARCHAR(64)).
+     * @param string $source Logical source / scope (e.g. "Users").
+     * @param mixed $primaryKey Identifier for the subject of the action,
+     *   typically the related entity id. May be null for actions not tied
+     *   to a single record.
+     * @param array|null $data Arbitrary payload describing what happened.
+     *   Stored in the `changed` column.
+     * @param array|null $original Optional prior state. Stored in `original`.
+     * @param array|null $meta Metadata. `user_id` and `user_display` keys
+     *   land in their dedicated columns; the rest goes into `meta`.
+     * @param string|null $displayValue Human-friendly label for the row.
+     *
+     * @return void
+     */
+    public static function log(
+        string $type,
+        string $source,
+        mixed $primaryKey = null,
+        ?array $data = null,
+        ?array $original = null,
+        ?array $meta = null,
+        ?string $displayValue = null,
+    ): void {
+        $event = new AuditCustomEvent(
+            $type,
+            Text::uuid(),
+            $primaryKey,
+            $source,
+            $data,
+            $original,
+            null,
+            $displayValue,
+        );
+
+        if ($meta !== null) {
+            $event->setMetaInfo($meta);
+        }
+
+        static::persister()->logEvents([$event]);
+    }
+
+    /**
+     * Override the persister used for emitting custom events. Useful for
+     * tests, or for applying non-default config (e.g. enabling hashChain).
+     *
+     * @param \AuditStash\PersisterInterface|null $persister
+     *
+     * @return void
+     */
+    public static function setPersister(?PersisterInterface $persister): void
+    {
+        static::$persister = $persister;
+    }
+
+    /**
+     * Returns the configured persister, lazily creating a default
+     * `TablePersister` on first use.
+     *
+     * @return \AuditStash\PersisterInterface
+     */
+    protected static function persister(): PersisterInterface
+    {
+        if (static::$persister === null) {
+            static::$persister = new TablePersister();
+        }
+
+        return static::$persister;
+    }
+}

--- a/src/Controller/Admin/AuditLogsController.php
+++ b/src/Controller/Admin/AuditLogsController.php
@@ -430,7 +430,7 @@ class AuditLogsController extends AppController
             ->where([
                 'source' => $source,
                 'primary_key' => $primaryKey,
-                'type' => AuditLogType::Delete,
+                'type' => AuditLogType::Delete->value,
             ])
             ->orderBy(['created' => 'DESC'])
             ->first();
@@ -560,7 +560,7 @@ class AuditLogsController extends AppController
             fputcsv($output, [
                 $log->id,
                 $log->transaction_key,
-                $log->type->value,
+                $log->type,
                 $log->source,
                 $log->primary_key,
                 $log->display_value,
@@ -602,7 +602,7 @@ class AuditLogsController extends AppController
             $data[] = [
                 'id' => $log->id,
                 'transaction_key' => $log->transaction_key,
-                'type' => $log->type->value,
+                'type' => $log->type,
                 'source' => $log->source,
                 'primary_key' => $log->primary_key,
                 'display_value' => $log->display_value,

--- a/src/Controller/Admin/AuditLogsController.php
+++ b/src/Controller/Admin/AuditLogsController.php
@@ -179,7 +179,24 @@ class AuditLogsController extends AppController
             ->orderBy(['source' => 'ASC'])
             ->toArray();
 
-        $eventTypes = ['create', 'update', 'delete'];
+        // Built-in CRUD types plus any custom action event types (e.g.
+        // "user.login") that have actually been recorded.
+        $distinctTypes = $this->AuditLogs->find()
+            ->select(['type'])
+            ->distinct(['type'])
+            ->orderBy(['type' => 'ASC'])
+            ->all()
+            ->extract('type')
+            ->toList();
+        $eventTypes = array_values(array_unique(array_merge(
+            [
+                AuditLogType::Create->value,
+                AuditLogType::Update->value,
+                AuditLogType::Delete->value,
+                AuditLogType::Revert->value,
+            ],
+            $distinctTypes,
+        )));
 
         // Get distinct changed fields for autocomplete
         $changedFields = $this->AuditLogs->getDistinctChangedFields();

--- a/src/Event/AuditCustomEvent.php
+++ b/src/Event/AuditCustomEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\Event;
+
+use Cake\Datasource\EntityInterface;
+
+/**
+ * Represents an audit log event for a custom action that does not map to
+ * entity create/update/delete (e.g. "user.login", "report.exported",
+ * "permission.granted").
+ *
+ * The type string is opaque to the plugin and persisted as-is. It must fit
+ * the audit_logs.type column (VARCHAR(64)).
+ */
+class AuditCustomEvent extends BaseEvent
+{
+    protected string $eventType;
+
+    /**
+     * @param string $eventType The custom event type identifier (e.g. "user.login").
+     * @param string $transactionId The global transaction id.
+     * @param mixed $id The primary key of the related entity, or any identifier
+     *   relevant to the action. May be null.
+     * @param string $source The source / scope name (e.g. "Users").
+     * @param array|null $data Arbitrary payload describing what happened.
+     *   Stored in the `changed` column.
+     * @param array|null $original Optional prior state. Stored in `original`.
+     * @param \Cake\Datasource\EntityInterface|null $entity Related entity, if any.
+     * @param string|null $displayValue Human-friendly label for the row.
+     */
+    public function __construct(
+        string $eventType,
+        string $transactionId,
+        mixed $id,
+        string $source,
+        ?array $data = null,
+        ?array $original = null,
+        ?EntityInterface $entity = null,
+        ?string $displayValue = null,
+    ) {
+        parent::__construct($transactionId, $id, $source, $data, $original, $entity, $displayValue);
+        $this->eventType = $eventType;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getEventType(): string
+    {
+        return $this->eventType;
+    }
+}

--- a/src/Event/AuditCustomEvent.php
+++ b/src/Event/AuditCustomEvent.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AuditStash\Event;
 
 use Cake\Datasource\EntityInterface;
+use InvalidArgumentException;
 
 /**
  * Represents an audit log event for a custom action that does not map to
@@ -29,6 +30,8 @@ class AuditCustomEvent extends BaseEvent
      * @param array|null $original Optional prior state. Stored in `original`.
      * @param \Cake\Datasource\EntityInterface|null $entity Related entity, if any.
      * @param string|null $displayValue Human-friendly label for the row.
+     *
+     * @throws \InvalidArgumentException When `$eventType` is empty or whitespace-only.
      */
     public function __construct(
         string $eventType,
@@ -40,6 +43,10 @@ class AuditCustomEvent extends BaseEvent
         ?EntityInterface $entity = null,
         ?string $displayValue = null,
     ) {
+        if (trim($eventType) === '') {
+            throw new InvalidArgumentException('Custom audit event type must be a non-empty string.');
+        }
+
         parent::__construct($transactionId, $id, $source, $data, $original, $entity, $displayValue);
         $this->eventType = $eventType;
     }

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AuditStash;
 
 use AuditStash\Event\AuditCreateEvent;
+use AuditStash\Event\AuditCustomEvent;
 use AuditStash\Event\AuditDeleteEvent;
 use AuditStash\Event\AuditUpdateEvent;
 use Cake\ORM\Entity;
@@ -49,13 +50,25 @@ class EventFactory
                 new Entity(),
                 $displayValue,
             );
-        } else {
+        } elseif ($data['type'] === 'update') {
             $event = new AuditUpdateEvent(
                 $data['transaction_key'],
                 $data['primary_key'],
                 $data['source'],
                 array_key_exists('changed', $data) ? $data['changed'] : [],
                 array_key_exists('original', $data) ? $data['original'] : [],
+                new Entity(),
+                $displayValue,
+            );
+        } else {
+            // Custom action event (e.g. user.login, report.exported)
+            $event = new AuditCustomEvent(
+                $data['type'],
+                $data['transaction_key'],
+                $data['primary_key'] ?? null,
+                $data['source'],
+                array_key_exists('changed', $data) ? $data['changed'] : null,
+                array_key_exists('original', $data) ? $data['original'] : null,
                 new Entity(),
                 $displayValue,
             );

--- a/src/Model/Entity/AuditLog.php
+++ b/src/Model/Entity/AuditLog.php
@@ -11,7 +11,7 @@ use Cake\ORM\Entity;
  *
  * @property int $id
  * @property string $transaction_key
- * @property \AuditStash\AuditLogType $type
+ * @property string $type
  * @property int|string|null $primary_key
  * @property string|null $display_value
  * @property string $source

--- a/src/Model/Table/AuditLogsTable.php
+++ b/src/Model/Table/AuditLogsTable.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace AuditStash\Model\Table;
 
-use AuditStash\AuditLogType;
 use AuditStash\Database\JsonQueryHelper;
-use Cake\Database\Type\EnumType;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
@@ -55,9 +53,9 @@ class AuditLogsTable extends Table
             ],
         ]);
 
-        $this->getSchema()->setColumnType('type', EnumType::from(AuditLogType::class));
-
-        // Set JSON column types for proper array handling
+        // type stays as plain string. Built-in events use AuditLogType enum
+        // values (create/update/delete/revert), but custom action events may
+        // use any string up to 64 chars.
         $this->getSchema()->setColumnType('original', 'json');
         $this->getSchema()->setColumnType('changed', 'json');
         $this->getSchema()->setColumnType('meta', 'json');

--- a/src/Monitor/Alert.php
+++ b/src/Monitor/Alert.php
@@ -90,7 +90,7 @@ class Alert
             'message' => $this->message,
             'audit_log' => [
                 'id' => $this->auditLog->id,
-                'type' => $this->auditLog->type->value,
+                'type' => $this->auditLog->type,
                 'source' => $this->auditLog->source,
                 'primary_key' => $this->auditLog->primary_key,
                 'transaction_key' => $this->auditLog->transaction_key,

--- a/src/Monitor/Rule/MassDeleteRule.php
+++ b/src/Monitor/Rule/MassDeleteRule.php
@@ -23,7 +23,7 @@ class MassDeleteRule extends AbstractRule
      */
     public function matches(AuditLog $auditLog): bool
     {
-        if ($auditLog->type !== AuditLogType::Delete) {
+        if ($auditLog->type !== AuditLogType::Delete->value) {
             return false;
         }
 

--- a/src/Monitor/Rule/UnusualTimeActivityRule.php
+++ b/src/Monitor/Rule/UnusualTimeActivityRule.php
@@ -63,7 +63,7 @@ class UnusualTimeActivityRule extends AbstractRule
 
         return sprintf(
             'Off-hours activity detected: %s operation on %s at %s',
-            ucfirst($auditLog->type->value),
+            ucfirst($auditLog->type),
             $auditLog->source,
             $created->format('Y-m-d H:i:s'),
         );
@@ -81,7 +81,7 @@ class UnusualTimeActivityRule extends AbstractRule
 
         return [
             'table' => $auditLog->source,
-            'operation' => $auditLog->type->value,
+            'operation' => $auditLog->type,
             'timestamp' => $created->toIso8601String(),
             'day_of_week' => $created->format('l'),
             'time_of_day' => $created->format('H:i:s'),

--- a/src/Service/GdprService.php
+++ b/src/Service/GdprService.php
@@ -170,7 +170,7 @@ class GdprService
             $data[] = [
                 'id' => $log->id,
                 'transaction_key' => $log->transaction_key,
-                'type' => $log->type->value ?? $log->type,
+                'type' => $log->type,
                 'source' => $log->source,
                 'primary_key' => $log->primary_key,
                 'display_value' => $log->display_value,

--- a/src/Service/RevertService.php
+++ b/src/Service/RevertService.php
@@ -206,7 +206,7 @@ class RevertService
 
         $auditLog = $auditLogs->newEntity([
             'transaction_key' => Text::uuid(),
-            'type' => AuditLogType::Revert,
+            'type' => AuditLogType::Revert->value,
             'source' => $source,
             'primary_key' => (string)$primaryKey,
             'original' => json_encode($currentState, AuditStashPlugin::JSON_FLAGS),

--- a/src/Service/StateReconstructorService.php
+++ b/src/Service/StateReconstructorService.php
@@ -40,11 +40,11 @@ class StateReconstructorService
 
         // Apply changes sequentially up to target
         foreach ($logs as $log) {
-            if ($log->type === AuditLogType::Create && $log->changed !== null) {
+            if ($log->type === AuditLogType::Create->value && $log->changed !== null) {
                 $state = is_string($log->changed)
                     ? (json_decode($log->changed, true) ?: [])
                     : $log->changed;
-            } elseif ($log->type === AuditLogType::Update && $log->changed !== null) {
+            } elseif ($log->type === AuditLogType::Update->value && $log->changed !== null) {
                 $changed = is_string($log->changed)
                     ? (json_decode($log->changed, true) ?: [])
                     : $log->changed;

--- a/src/View/Helper/AuditHelper.php
+++ b/src/View/Helper/AuditHelper.php
@@ -362,17 +362,21 @@ class AuditHelper extends Helper
     /**
      * Display event type badge
      *
-     * @param \AuditStash\AuditLogType $type Event type
+     * @param \AuditStash\AuditLogType|string $type Event type — built-in
+     *   AuditLogType case, or any custom action event type string.
      *
      * @return string HTML badge
      */
-    public function eventTypeBadge(AuditLogType $type): string
+    public function eventTypeBadge(AuditLogType|string $type): string
     {
-        return match ($type) {
-            AuditLogType::Create => '<span class="badge bg-success">Create</span>',
-            AuditLogType::Update => '<span class="badge bg-primary">Update</span>',
-            AuditLogType::Delete => '<span class="badge bg-danger">Delete</span>',
-            AuditLogType::Revert => '<span class="badge bg-warning">Revert</span>',
+        $value = $type instanceof AuditLogType ? $type->value : $type;
+
+        return match ($value) {
+            AuditLogType::Create->value => '<span class="badge bg-success">Create</span>',
+            AuditLogType::Update->value => '<span class="badge bg-primary">Update</span>',
+            AuditLogType::Delete->value => '<span class="badge bg-danger">Delete</span>',
+            AuditLogType::Revert->value => '<span class="badge bg-warning">Revert</span>',
+            default => '<span class="badge bg-secondary">' . h($value) . '</span>',
         };
     }
 

--- a/templates/Admin/AuditLogs/timeline.php
+++ b/templates/Admin/AuditLogs/timeline.php
@@ -45,8 +45,10 @@ use AuditStash\AuditLogType;
                                     <div class="marker marker-primary"></div>
                                 <?php } elseif ($auditLog->type === AuditLogType::Revert->value) { ?>
                                     <div class="marker marker-warning"></div>
-                                <?php } else { ?>
+                                <?php } elseif ($auditLog->type === AuditLogType::Delete->value) { ?>
                                     <div class="marker marker-danger"></div>
+                                <?php } else { ?>
+                                    <div class="marker marker-secondary"></div>
                                 <?php } ?>
                                 <?php if ($index < count($auditLogs) - 1) { ?>
                                     <div class="timeline-line"></div>
@@ -69,8 +71,10 @@ use AuditStash\AuditLogType;
                                                 $revertType = $meta['revert_type'] ?? 'unknown';
                                                 ?>
                                                 Record reverted (<?= h($revertType) ?>)
-                                            <?php } else { ?>
+                                            <?php } elseif ($auditLog->type === AuditLogType::Delete->value) { ?>
                                                 Record deleted
+                                            <?php } else { ?>
+                                                <?= h($auditLog->type) ?>
                                             <?php } ?>
                                         </span>
                                     </div>
@@ -82,7 +86,7 @@ use AuditStash\AuditLogType;
                                         ) ?>
                                         <?php if ($auditLog->type === AuditLogType::Delete->value) { ?>
                                             <?= $this->Audit->restoreButton($auditLog->source, $auditLog->primary_key) ?>
-                                        <?php } elseif ($auditLog->type !== AuditLogType::Revert->value) { ?>
+                                        <?php } elseif (in_array($auditLog->type, [AuditLogType::Create->value, AuditLogType::Update->value], true)) { ?>
                                             <?= $this->Audit->revertButton($auditLog->id) ?>
                                         <?php } ?>
                                     </div>
@@ -152,6 +156,31 @@ use AuditStash\AuditLogType;
                                                 <?= $this->Audit->diffInline($auditLog->original, $auditLog->changed) ?>
                                             </div>
                                         </details>
+                                    <?php } else { ?>
+                                        <?php
+                                        $changed = is_string($auditLog->changed) ? json_decode($auditLog->changed, true) : $auditLog->changed;
+                                        if ($changed && is_array($changed)) {
+                                            ?>
+                                            <div class="changes-preview">
+                                                <strong>Event payload:</strong>
+                                                <ul class="mb-0">
+                                                    <?php
+                                                    $count = 0;
+                                                    foreach ($changed as $field => $value) {
+                                                        if ($count < 5) {
+                                                            echo '<li><code>' . h($field) . '</code>: ' . h(is_array($value) ? json_encode($value) : $value) . '</li>';
+                                                        }
+                                                        $count++;
+                                                    }
+                                                    if ($count > 5) {
+                                                        echo '<li><em>... and ' . ($count - 5) . ' more fields</em></li>';
+                                                    }
+                                                    ?>
+                                                </ul>
+                                            </div>
+                                            <?php
+                                        }
+                                        ?>
                                     <?php } ?>
                                 </div>
                             </div>

--- a/templates/Admin/AuditLogs/timeline.php
+++ b/templates/Admin/AuditLogs/timeline.php
@@ -39,11 +39,11 @@ use AuditStash\AuditLogType;
                         </div>
                         <div class="col-md-1 text-center">
                             <div class="timeline-marker">
-                                <?php if ($auditLog->type === AuditLogType::Create) { ?>
+                                <?php if ($auditLog->type === AuditLogType::Create->value) { ?>
                                     <div class="marker marker-success"></div>
-                                <?php } elseif ($auditLog->type === AuditLogType::Update) { ?>
+                                <?php } elseif ($auditLog->type === AuditLogType::Update->value) { ?>
                                     <div class="marker marker-primary"></div>
-                                <?php } elseif ($auditLog->type === AuditLogType::Revert) { ?>
+                                <?php } elseif ($auditLog->type === AuditLogType::Revert->value) { ?>
                                     <div class="marker marker-warning"></div>
                                 <?php } else { ?>
                                     <div class="marker marker-danger"></div>
@@ -59,11 +59,11 @@ use AuditStash\AuditLogType;
                                     <div>
                                         <?= $this->Audit->eventTypeBadge($auditLog->type) ?>
                                         <span class="ms-2">
-                                            <?php if ($auditLog->type === AuditLogType::Create) { ?>
+                                            <?php if ($auditLog->type === AuditLogType::Create->value) { ?>
                                                 Record created
-                                            <?php } elseif ($auditLog->type === AuditLogType::Update) { ?>
+                                            <?php } elseif ($auditLog->type === AuditLogType::Update->value) { ?>
                                                 <?= $this->Audit->changeSummary($auditLog->changed) ?>
-                                            <?php } elseif ($auditLog->type === AuditLogType::Revert) { ?>
+                                            <?php } elseif ($auditLog->type === AuditLogType::Revert->value) { ?>
                                                 <?php
                                                 $meta = is_string($auditLog->meta) ? json_decode($auditLog->meta, true) : $auditLog->meta;
                                                 $revertType = $meta['revert_type'] ?? 'unknown';
@@ -80,9 +80,9 @@ use AuditStash\AuditLogType;
                                             ['action' => 'view', $auditLog->id],
                                             ['class' => 'btn btn-sm btn-outline-primary']
                                         ) ?>
-                                        <?php if ($auditLog->type === AuditLogType::Delete) { ?>
+                                        <?php if ($auditLog->type === AuditLogType::Delete->value) { ?>
                                             <?= $this->Audit->restoreButton($auditLog->source, $auditLog->primary_key) ?>
-                                        <?php } elseif ($auditLog->type !== AuditLogType::Revert) { ?>
+                                        <?php } elseif ($auditLog->type !== AuditLogType::Revert->value) { ?>
                                             <?= $this->Audit->revertButton($auditLog->id) ?>
                                         <?php } ?>
                                     </div>
@@ -102,7 +102,7 @@ use AuditStash\AuditLogType;
                                         </div>
                                     </div>
 
-                                    <?php if ($auditLog->type === AuditLogType::Create) { ?>
+                                    <?php if ($auditLog->type === AuditLogType::Create->value) { ?>
                                         <div class="changes-preview">
                                             <strong>Initial values:</strong>
                                             <?php
@@ -123,18 +123,18 @@ use AuditStash\AuditLogType;
                                             }
                                             ?>
                                         </div>
-                                    <?php } elseif ($auditLog->type === AuditLogType::Update) { ?>
+                                    <?php } elseif ($auditLog->type === AuditLogType::Update->value) { ?>
                                         <details>
                                             <summary class="cursor-pointer text-primary">Show changes</summary>
                                             <div class="mt-2">
                                                 <?= $this->Audit->diffInline($auditLog->original, $auditLog->changed) ?>
                                             </div>
                                         </details>
-                                    <?php } elseif ($auditLog->type === AuditLogType::Delete) { ?>
+                                    <?php } elseif ($auditLog->type === AuditLogType::Delete->value) { ?>
                                         <div class="alert alert-danger mb-0">
                                             <strong>Record was deleted</strong>
                                         </div>
-                                    <?php } elseif ($auditLog->type === AuditLogType::Revert) { ?>
+                                    <?php } elseif ($auditLog->type === AuditLogType::Revert->value) { ?>
                                         <div class="alert alert-warning mb-2">
                                             <?php
                                             $meta = is_string($auditLog->meta) ? json_decode($auditLog->meta, true) : $auditLog->meta;

--- a/templates/Admin/AuditLogs/view.php
+++ b/templates/Admin/AuditLogs/view.php
@@ -100,13 +100,15 @@ use AuditStash\AuditLogType;
                 <?= $this->Audit->fieldValuesTable($auditLog->changed, __('Created with values:')) ?>
             <?php } elseif ($auditLog->type === AuditLogType::Delete->value) { ?>
                 <?= $this->Audit->fieldValuesTable($auditLog->original, __('Deleted record had these values:')) ?>
-            <?php } else { ?>
+            <?php } elseif (in_array($auditLog->type, [AuditLogType::Update->value, AuditLogType::Revert->value], true)) { ?>
                 <div id="inline-diff-view">
                     <?= $this->Audit->diffInline($auditLog->original, $auditLog->changed) ?>
                 </div>
                 <div id="side-diff-view" style="display: none;">
                     <?= $this->Audit->diff($auditLog->original, $auditLog->changed) ?>
                 </div>
+            <?php } else { ?>
+                <?= $this->Audit->fieldValuesTable($auditLog->changed, __('Event payload:')) ?>
             <?php } ?>
         </div>
     </div>

--- a/templates/Admin/AuditLogs/view.php
+++ b/templates/Admin/AuditLogs/view.php
@@ -82,13 +82,13 @@ use AuditStash\AuditLogType;
         <div class="card-header d-flex justify-content-between align-items-center">
             <h5 class="mb-0">
                 <?= __('Changes') ?>
-                <?php if ($auditLog->type === AuditLogType::Create) { ?>
+                <?php if ($auditLog->type === AuditLogType::Create->value) { ?>
                     <span class="badge bg-info"><?= __('New Record') ?></span>
-                <?php } elseif ($auditLog->type === AuditLogType::Delete) { ?>
+                <?php } elseif ($auditLog->type === AuditLogType::Delete->value) { ?>
                     <span class="badge bg-danger"><?= __('Deleted Record') ?></span>
                 <?php } ?>
             </h5>
-            <?php if ($auditLog->type === AuditLogType::Update) { ?>
+            <?php if ($auditLog->type === AuditLogType::Update->value) { ?>
             <div class="btn-group btn-group-sm" role="group">
                 <button type="button" class="btn btn-outline-secondary active" id="btn-inline-diff"><?= __('Inline') ?></button>
                 <button type="button" class="btn btn-outline-secondary" id="btn-side-diff"><?= __('Side-by-side') ?></button>
@@ -96,9 +96,9 @@ use AuditStash\AuditLogType;
             <?php } ?>
         </div>
         <div class="card-body">
-            <?php if ($auditLog->type === AuditLogType::Create) { ?>
+            <?php if ($auditLog->type === AuditLogType::Create->value) { ?>
                 <?= $this->Audit->fieldValuesTable($auditLog->changed, __('Created with values:')) ?>
-            <?php } elseif ($auditLog->type === AuditLogType::Delete) { ?>
+            <?php } elseif ($auditLog->type === AuditLogType::Delete->value) { ?>
                 <?= $this->Audit->fieldValuesTable($auditLog->original, __('Deleted record had these values:')) ?>
             <?php } else { ?>
                 <div id="inline-diff-view">

--- a/templates/email/html/audit_alert.php
+++ b/templates/email/html/audit_alert.php
@@ -101,7 +101,7 @@ $severityColor = $severityColors[$alert->getSeverity()] ?? '#6c757d';
                     </tr>
                     <tr>
                         <td>Type</td>
-                        <td><?= h(ucfirst($auditLog->type->value)) ?></td>
+                        <td><?= h(ucfirst($auditLog->type)) ?></td>
                     </tr>
                     <tr>
                         <td>Table</td>

--- a/templates/email/text/audit_alert.php
+++ b/templates/email/text/audit_alert.php
@@ -22,7 +22,7 @@ Audit Log Details:
 ------------------
 ID: <?= $auditLog->id ?>
 
-Type: <?= ucfirst($auditLog->type->value) ?>
+Type: <?= ucfirst($auditLog->type) ?>
 
 Table: <?= $auditLog->source ?>
 

--- a/tests/Fixture/AuditLogsFixture.php
+++ b/tests/Fixture/AuditLogsFixture.php
@@ -19,7 +19,7 @@ class AuditLogsFixture extends TestFixture
     public array $fields = [
         'id' => ['type' => 'integer', 'length' => 10, 'unsigned' => true, 'null' => false, 'default' => null, 'autoIncrement' => true],
         'transaction_key' => ['type' => 'string', 'length' => 36, 'null' => false, 'default' => null],
-        'type' => ['type' => 'string', 'length' => 7, 'null' => false, 'default' => null],
+        'type' => ['type' => 'string', 'length' => 64, 'null' => false, 'default' => null],
         'primary_key' => ['type' => 'integer', 'length' => 10, 'unsigned' => true, 'null' => true, 'default' => null],
         'display_value' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null],
         'source' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null],

--- a/tests/TestCase/AuditTest.php
+++ b/tests/TestCase/AuditTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\Test\TestCase;
+
+use AuditStash\Audit;
+use AuditStash\Event\AuditCustomEvent;
+use AuditStash\PersisterInterface;
+use Cake\TestSuite\TestCase;
+
+class AuditTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        Audit::setPersister(null);
+        parent::tearDown();
+    }
+
+    public function testLogDispatchesCustomEventToPersister(): void
+    {
+        $captured = [];
+        Audit::setPersister(new class ($captured) implements PersisterInterface {
+            /** @param array<\AuditStash\EventInterface> $captured */
+            public function __construct(private array &$captured)
+            {
+            }
+
+            public function logEvents(array $auditLogs): void
+            {
+                foreach ($auditLogs as $log) {
+                    $this->captured[] = $log;
+                }
+            }
+        });
+
+        Audit::log(
+            type: 'user.login',
+            source: 'Users',
+            primaryKey: 7,
+            data: ['ip' => '10.0.0.1'],
+            meta: ['user_id' => 7, 'user_display' => 'Alice'],
+            displayValue: 'Alice',
+        );
+
+        $this->assertCount(1, $captured);
+        $event = $captured[0];
+        $this->assertInstanceOf(AuditCustomEvent::class, $event);
+        $this->assertSame('user.login', $event->getEventType());
+        $this->assertSame('Users', $event->getSourceName());
+        $this->assertSame(7, $event->getId());
+        $this->assertSame(['ip' => '10.0.0.1'], $event->getChanged());
+        $this->assertSame(['user_id' => 7, 'user_display' => 'Alice'], $event->getMetaInfo());
+        $this->assertSame('Alice', $event->getDisplayValue());
+        $this->assertNotEmpty($event->getTransactionId());
+    }
+
+    public function testLogGeneratesUniqueTransactionIdPerCall(): void
+    {
+        $captured = [];
+        Audit::setPersister(new class ($captured) implements PersisterInterface {
+            /** @param array<\AuditStash\EventInterface> $captured */
+            public function __construct(private array &$captured)
+            {
+            }
+
+            public function logEvents(array $auditLogs): void
+            {
+                foreach ($auditLogs as $log) {
+                    $this->captured[] = $log;
+                }
+            }
+        });
+
+        Audit::log('user.login', 'Users', 1);
+        Audit::log('user.login', 'Users', 2);
+
+        $this->assertCount(2, $captured);
+        $this->assertNotSame($captured[0]->getTransactionId(), $captured[1]->getTransactionId());
+    }
+}

--- a/tests/TestCase/Event/AuditCustomEventTest.php
+++ b/tests/TestCase/Event/AuditCustomEventTest.php
@@ -6,6 +6,8 @@ namespace AuditStash\Test\TestCase\Event;
 
 use AuditStash\Event\AuditCustomEvent;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AuditCustomEventTest extends TestCase
 {
@@ -56,5 +58,36 @@ class AuditCustomEventTest extends TestCase
         $event->setMetaInfo(['user_id' => 7, 'ip' => '10.0.0.1']);
 
         $this->assertSame(['user_id' => 7, 'ip' => '10.0.0.1'], $event->getMetaInfo());
+    }
+
+    /**
+     * @return array<array{0: string}>
+     */
+    public static function emptyEventTypeProvider(): array
+    {
+        return [
+            [''],
+            [' '],
+            ["\t\n"],
+        ];
+    }
+
+    /**
+     * @param string $eventType
+     *
+     * @return void
+     */
+    #[DataProvider('emptyEventTypeProvider')]
+    public function testEmptyEventTypeIsRejected(string $eventType): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('non-empty string');
+
+        new AuditCustomEvent(
+            $eventType,
+            '00000000-0000-4000-a000-000000000004',
+            null,
+            'Users',
+        );
     }
 }

--- a/tests/TestCase/Event/AuditCustomEventTest.php
+++ b/tests/TestCase/Event/AuditCustomEventTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\Test\TestCase\Event;
+
+use AuditStash\Event\AuditCustomEvent;
+use Cake\TestSuite\TestCase;
+
+class AuditCustomEventTest extends TestCase
+{
+    public function testGetEventTypeReturnsCustomString(): void
+    {
+        $event = new AuditCustomEvent(
+            'user.login',
+            '00000000-0000-4000-a000-000000000001',
+            7,
+            'Users',
+            ['ip' => '127.0.0.1'],
+        );
+
+        $this->assertSame('user.login', $event->getEventType());
+        $this->assertSame('Users', $event->getSourceName());
+        $this->assertSame(7, $event->getId());
+        $this->assertSame(['ip' => '127.0.0.1'], $event->getChanged());
+        $this->assertNull($event->getOriginal());
+    }
+
+    public function testJsonSerializeRoundTripPreservesCustomType(): void
+    {
+        $event = new AuditCustomEvent(
+            'report.exported',
+            '00000000-0000-4000-a000-000000000002',
+            null,
+            'Reports',
+            ['format' => 'csv', 'rows' => 1234],
+        );
+
+        $serialized = $event->jsonSerialize();
+
+        $this->assertIsArray($serialized);
+        $this->assertSame('report.exported', $serialized['type']);
+        $this->assertSame('Reports', $serialized['source']);
+        $this->assertSame(['format' => 'csv', 'rows' => 1234], $serialized['changed']);
+    }
+
+    public function testMetaInfoCanBeAttached(): void
+    {
+        $event = new AuditCustomEvent(
+            'user.login',
+            '00000000-0000-4000-a000-000000000003',
+            7,
+            'Users',
+        );
+
+        $event->setMetaInfo(['user_id' => 7, 'ip' => '10.0.0.1']);
+
+        $this->assertSame(['user_id' => 7, 'ip' => '10.0.0.1'], $event->getMetaInfo());
+    }
+}

--- a/tests/TestCase/EventFactoryTest.php
+++ b/tests/TestCase/EventFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\Test\TestCase;
+
+use AuditStash\Event\AuditCreateEvent;
+use AuditStash\Event\AuditCustomEvent;
+use AuditStash\Event\AuditDeleteEvent;
+use AuditStash\Event\AuditUpdateEvent;
+use AuditStash\EventFactory;
+use Cake\TestSuite\TestCase;
+
+class EventFactoryTest extends TestCase
+{
+    private EventFactory $factory;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new EventFactory();
+    }
+
+    public function testCreatesAuditCreateEventForCreateType(): void
+    {
+        $event = $this->factory->create($this->row('create'));
+        $this->assertInstanceOf(AuditCreateEvent::class, $event);
+    }
+
+    public function testCreatesAuditUpdateEventForUpdateType(): void
+    {
+        $event = $this->factory->create($this->row('update'));
+        $this->assertInstanceOf(AuditUpdateEvent::class, $event);
+    }
+
+    public function testCreatesAuditDeleteEventForDeleteType(): void
+    {
+        $event = $this->factory->create($this->row('delete'));
+        $this->assertInstanceOf(AuditDeleteEvent::class, $event);
+    }
+
+    public function testFallsBackToCustomEventForUnknownType(): void
+    {
+        $event = $this->factory->create($this->row('user.login'));
+
+        $this->assertInstanceOf(AuditCustomEvent::class, $event);
+        $this->assertSame('user.login', $event->getEventType());
+        $this->assertSame('Users', $event->getSourceName());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function row(string $type): array
+    {
+        return [
+            'type' => $type,
+            'transaction_key' => '00000000-0000-4000-a000-000000000001',
+            'primary_key' => 7,
+            'source' => 'Users',
+            'parent_source' => null,
+            'changed' => ['ip' => '127.0.0.1'],
+            'original' => [],
+            'meta' => [],
+            '@timestamp' => '2026-05-03T10:00:00.000000+00:00',
+            'display_value' => 'Alice',
+        ];
+    }
+}

--- a/tests/TestCase/Monitor/Channel/LogChannelTest.php
+++ b/tests/TestCase/Monitor/Channel/LogChannelTest.php
@@ -57,7 +57,7 @@ class LogChannelTest extends TestCase
 
         $auditLog = new AuditLog([
             'id' => 1,
-            'type' => AuditLogType::Delete,
+            'type' => AuditLogType::Delete->value,
             'source' => 'users',
             'primary_key' => 123,
             'transaction_key' => 'abc-123',
@@ -99,7 +99,7 @@ class LogChannelTest extends TestCase
         foreach ($testCases as $severity => $expectedLevel) {
             $auditLog = new AuditLog([
                 'id' => 1,
-                'type' => AuditLogType::Delete,
+                'type' => AuditLogType::Delete->value,
                 'source' => 'test',
                 'primary_key' => 1,
                 'transaction_key' => 'test',

--- a/tests/TestCase/Monitor/Rule/MassDeleteRuleTest.php
+++ b/tests/TestCase/Monitor/Rule/MassDeleteRuleTest.php
@@ -40,7 +40,7 @@ class MassDeleteRuleTest extends TestCase
         // Create multiple delete events
         for ($i = 0; $i < 3; $i++) {
             $auditLogsTable->save($auditLogsTable->newEntity([
-                'type' => AuditLogType::Delete,
+                'type' => AuditLogType::Delete->value,
                 'transaction_key' => 'test-' . $i,
                 'source' => 'users',
                 'primary_key' => $i + 1,
@@ -48,7 +48,7 @@ class MassDeleteRuleTest extends TestCase
         }
 
         $testLog = $auditLogsTable->newEntity([
-            'type' => AuditLogType::Delete,
+            'type' => AuditLogType::Delete->value,
             'transaction_key' => 'test',
             'source' => 'users',
             'primary_key' => 999,
@@ -70,7 +70,7 @@ class MassDeleteRuleTest extends TestCase
         ]);
 
         $testLog = new AuditLog([
-            'type' => AuditLogType::Delete,
+            'type' => AuditLogType::Delete->value,
             'source' => 'users',
             'primary_key' => 1,
         ]);
@@ -90,7 +90,7 @@ class MassDeleteRuleTest extends TestCase
         ]);
 
         $testLog = new AuditLog([
-            'type' => AuditLogType::Update,
+            'type' => AuditLogType::Update->value,
             'source' => 'users',
             'primary_key' => 1,
         ]);
@@ -111,7 +111,7 @@ class MassDeleteRuleTest extends TestCase
         ]);
 
         $testLog = new AuditLog([
-            'type' => AuditLogType::Delete,
+            'type' => AuditLogType::Delete->value,
             'source' => 'users',
             'primary_key' => 1,
         ]);
@@ -144,7 +144,7 @@ class MassDeleteRuleTest extends TestCase
 
         for ($i = 0; $i < 5; $i++) {
             $auditLogsTable->save($auditLogsTable->newEntity([
-                'type' => AuditLogType::Delete,
+                'type' => AuditLogType::Delete->value,
                 'transaction_key' => 'test-' . $i,
                 'source' => 'posts',
                 'primary_key' => $i + 1,
@@ -157,7 +157,7 @@ class MassDeleteRuleTest extends TestCase
         ]);
 
         $testLog = new AuditLog([
-            'type' => AuditLogType::Delete,
+            'type' => AuditLogType::Delete->value,
             'source' => 'posts',
             'primary_key' => 999,
         ]);
@@ -181,7 +181,7 @@ class MassDeleteRuleTest extends TestCase
         ]);
 
         $testLog = new AuditLog([
-            'type' => AuditLogType::Delete,
+            'type' => AuditLogType::Delete->value,
             'source' => 'users',
             'primary_key' => 1,
         ]);

--- a/tests/TestCase/Service/RevertServiceTest.php
+++ b/tests/TestCase/Service/RevertServiceTest.php
@@ -83,7 +83,7 @@ class RevertServiceTest extends TestCase
 
         // Check that a revert audit log was created
         $revertLog = $auditLogs->find()
-            ->where(['type' => AuditLogType::Revert])
+            ->where(['type' => AuditLogType::Revert->value])
             ->first();
 
         $this->assertNotNull($revertLog);
@@ -134,7 +134,7 @@ class RevertServiceTest extends TestCase
 
         // Check that a partial revert audit log was created
         $revertLog = $auditLogs->find()
-            ->where(['type' => AuditLogType::Revert])
+            ->where(['type' => AuditLogType::Revert->value])
             ->first();
 
         $this->assertNotNull($revertLog);
@@ -181,7 +181,7 @@ class RevertServiceTest extends TestCase
 
         // Check that a restore audit log was created
         $revertLog = $auditLogs->find()
-            ->where(['type' => AuditLogType::Revert])
+            ->where(['type' => AuditLogType::Revert->value])
             ->first();
 
         $this->assertNotNull($revertLog);


### PR DESCRIPTION
## Summary

Adds a static facade for emitting audit events that don't map to entity CRUD — logins, exports, permission grants, etc. — flowing through the same persister, hash chain, and viewer as existing Create/Update/Delete events.

```php
use AuditStash\Audit;

Audit::log(
    type: 'user.login',
    source: 'Users',
    primaryKey: \$user->id,
    data: ['ip' => \$request->clientIp()],
    meta: ['user_id' => \$user->id, 'user_display' => \$user->name],
);
```

## What's in the PR

- **`AuditStash\Audit`** — static facade. `log()` builds an `AuditCustomEvent`, generates a UUID transaction id, dispatches via the persister. `setPersister()` for tests / non-default config.
- **`Event\AuditCustomEvent`** — extends `BaseEvent`, carries a user-supplied type string.
- **`EventFactory`** — falls back to `AuditCustomEvent` for unknown types so replays from raw rows work.
- **Migration** — `audit_logs.type` widened from `VARCHAR(7)` to `VARCHAR(64)`. Single-purpose, no other schema changes.
- **`AuditLogsTable`** — removed `setColumnType('type', EnumType::from(AuditLogType::class))`. The enum mapping was rejecting any row whose `type` wasn't one of the four built-in cases. Column is now plain string. Internal `=== AuditLogType::X` comparisons updated to `->value`.
- **`AuditHelper::eventTypeBadge()`** — now accepts `AuditLogType|string`, renders a generic badge for unknown types.
- **README** — new Custom Action Events section.
- **Tests** — `AuditTest`, `AuditCustomEventTest`, `EventFactoryTest`. Existing tests updated where they passed enums where strings are now expected.

## BC

\`\$auditLog->type\` is now \`string\` instead of \`AuditLogType\` enum. Call \`AuditLogType::tryFrom(\$log->type)\` to get the enum form when needed. Built-in events keep their existing string values (\`create\`, \`update\`, \`delete\`, \`revert\`) — DB rows for built-in types are unchanged.

## Out of scope

- No new monitoring rules tailored to custom event types (existing rules can already match on \`type\` strings).
- No GdprService changes — it operates on entity-tied logs only.
- No CLI command for emitting custom events from scripts.

## Quality gates

- \`vendor/bin/phpunit\` — 298 tests pass
- \`vendor/bin/phpstan\` — clean
- \`vendor/bin/phpcs\` — clean

Marked **draft** for design discussion before merging.