### PR TITLE
Handle enum/Stringable display fields in AuditLogBehavior

### DIFF
--- a/src/Model/Behavior/AuditLogBehavior.php
+++ b/src/Model/Behavior/AuditLogBehavior.php
@@ -12,6 +12,7 @@ use AuditStash\Event\BaseEvent;
 use AuditStash\Filter\ChangeFilter;
 use AuditStash\Persister\TablePersister;
 use AuditStash\PersisterInterface;
+use BackedEnum;
 use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
@@ -21,6 +22,8 @@ use Cake\ORM\Behavior;
 use Cake\Utility\Inflector;
 use Cake\Utility\Text;
 use SplObjectStorage;
+use Stringable;
+use UnitEnum;
 use function Cake\Collection\collection;
 
 /**
@@ -212,11 +215,7 @@ class AuditLogBehavior extends Behavior
         $auditEvent = $entity->isNew() ? AuditCreateEvent::class : AuditUpdateEvent::class;
 
         // Get display field value for human-friendly identification
-        $displayField = $this->_table->getDisplayField();
-        $displayValue = null;
-        if (is_string($displayField) && $entity->has($displayField)) {
-            $displayValue = (string)$entity->get($displayField);
-        }
+        $displayValue = $this->extractDisplayValue($entity, $this->_table->getDisplayField());
 
         return new $auditEvent(
             $transactionId,
@@ -365,11 +364,7 @@ class AuditLogBehavior extends Behavior
         $primary = $entity->extract((array)$this->_table->getPrimaryKey());
 
         // Get display field value for human-friendly identification
-        $displayField = $this->_table->getDisplayField();
-        $displayValue = null;
-        if (is_string($displayField) && $entity->has($displayField)) {
-            $displayValue = (string)$entity->get($displayField);
-        }
+        $displayValue = $this->extractDisplayValue($entity, $this->_table->getDisplayField());
 
         // Capture original values before deletion
         $config = $this->_config;
@@ -430,10 +425,7 @@ class AuditLogBehavior extends Behavior
             $primary = $dependentEntity->extract((array)$primaryKey);
 
             // Get display value
-            $displayValue = null;
-            if (is_string($displayField) && $dependentEntity->has($displayField)) {
-                $displayValue = (string)$dependentEntity->get($displayField);
-            }
+            $displayValue = $this->extractDisplayValue($dependentEntity, $displayField);
 
             // Get original values
             $original = $dependentEntity->toArray();
@@ -493,6 +485,46 @@ class AuditLogBehavior extends Behavior
         $existingPersister = $this->persister;
 
         return $existingPersister;
+    }
+
+    /**
+     * Resolves a human-friendly display value for an entity, tolerating
+     * non-stringable column types (most importantly backed/unit enums and
+     * value objects implementing `Stringable`). Composite display fields,
+     * unsupported value types, and missing fields all yield `null` so the
+     * audit log row is still written.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Entity to read from
+     * @param array<string>|string|null $displayField Display field name as
+     *   returned by `Table::getDisplayField()`
+     *
+     * @return string|null
+     */
+    protected function extractDisplayValue(EntityInterface $entity, array|string|null $displayField): ?string
+    {
+        if (!is_string($displayField) || !$entity->has($displayField)) {
+            return null;
+        }
+
+        $value = $entity->get($displayField);
+
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof BackedEnum) {
+            return (string)$value->value;
+        }
+
+        if ($value instanceof UnitEnum) {
+            return $value->name;
+        }
+
+        if (is_scalar($value) || $value instanceof Stringable) {
+            return (string)$value;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/AuditLogBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/AuditLogBehaviorTest.php
@@ -6,6 +6,7 @@ namespace AuditStash\Test\TestCase\Model\Behavior;
 
 use ArrayObject;
 use AuditStash\Event\AuditCreateEvent;
+use AuditStash\Event\AuditDeleteEvent;
 use AuditStash\Event\AuditUpdateEvent;
 use AuditStash\Model\Behavior\AuditLogBehavior;
 use Cake\Core\Configure;
@@ -15,6 +16,9 @@ use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SplObjectStorage;
+use Stringable;
+use TestApp\Model\Enum\InvoiceTypeEnum;
+use TestApp\Model\Enum\PriorityEnum;
 
 class AuditLogBehaviorTest extends TestCase
 {
@@ -246,5 +250,106 @@ class AuditLogBehaviorTest extends TestCase
         $changed = $event->getChanged();
         $this->assertArrayHasKey('body', $changed);
         $this->assertEquals('****', $changed['body']);
+    }
+
+    /**
+     * Display field holding a backed enum must serialize to its scalar value
+     * instead of throwing "Object of class ... could not be converted to string".
+     *
+     * @return void
+     */
+    public function testDisplayValueWithBackedEnum(): void
+    {
+        $this->table->setDisplayField('title');
+        $entity = new Entity([
+            'id' => 1,
+            'title' => InvoiceTypeEnum::Anzahl,
+            'body' => 'Body',
+            'author_id' => 1,
+        ], ['markNew' => true]);
+
+        $queue = new SplObjectStorage();
+        $this->behavior->afterSave(new Event('Model.afterSave'), $entity, new ArrayObject([
+            '_auditQueue' => $queue,
+            '_auditTransaction' => '1',
+            'associated' => [],
+        ]));
+
+        $this->assertSame('Anzahlungsrechnung', $queue[$entity]->getDisplayValue());
+    }
+
+    /**
+     * @return void
+     */
+    public function testDisplayValueWithUnitEnum(): void
+    {
+        $this->table->setDisplayField('title');
+        $entity = new Entity([
+            'id' => 1,
+            'title' => PriorityEnum::First,
+            'body' => 'Body',
+            'author_id' => 1,
+        ], ['markNew' => true]);
+
+        $queue = new SplObjectStorage();
+        $this->behavior->afterSave(new Event('Model.afterSave'), $entity, new ArrayObject([
+            '_auditQueue' => $queue,
+            '_auditTransaction' => '1',
+            'associated' => [],
+        ]));
+
+        $this->assertSame('First', $queue[$entity]->getDisplayValue());
+    }
+
+    /**
+     * @return void
+     */
+    public function testDisplayValueWithStringableObject(): void
+    {
+        $this->table->setDisplayField('title');
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'rendered title';
+            }
+        };
+        $entity = new Entity([
+            'id' => 1,
+            'title' => $stringable,
+            'body' => 'Body',
+            'author_id' => 1,
+        ], ['markNew' => true]);
+
+        $queue = new SplObjectStorage();
+        $this->behavior->afterSave(new Event('Model.afterSave'), $entity, new ArrayObject([
+            '_auditQueue' => $queue,
+            '_auditTransaction' => '1',
+            'associated' => [],
+        ]));
+
+        $this->assertSame('rendered title', $queue[$entity]->getDisplayValue());
+    }
+
+    /**
+     * @return void
+     */
+    public function testDisplayValueWithBackedEnumOnDelete(): void
+    {
+        $this->table->setDisplayField('title');
+        $entity = new Entity([
+            'id' => 1,
+            'title' => InvoiceTypeEnum::Schluss,
+            'body' => 'Body',
+            'author_id' => 1,
+        ], ['markNew' => false, 'markClean' => true]);
+
+        $queue = new SplObjectStorage();
+        $this->behavior->afterDelete(new Event('Model.afterDelete'), $entity, new ArrayObject([
+            '_auditQueue' => $queue,
+            '_auditTransaction' => '1',
+        ]));
+
+        $this->assertInstanceOf(AuditDeleteEvent::class, $queue[$entity]);
+        $this->assertSame('Schlussrechnung', $queue[$entity]->getDisplayValue());
     }
 }

--- a/tests/test_app/src/Model/Enum/InvoiceTypeEnum.php
+++ b/tests/test_app/src/Model/Enum/InvoiceTypeEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp\Model\Enum;
+
+enum InvoiceTypeEnum: string
+{
+    case Anzahl = 'Anzahlungsrechnung';
+    case Schluss = 'Schlussrechnung';
+}

--- a/tests/test_app/src/Model/Enum/PriorityEnum.php
+++ b/tests/test_app/src/Model/Enum/PriorityEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp\Model\Enum;
+
+enum PriorityEnum
+{
+    case First;
+    case Second;
+}


### PR DESCRIPTION
Closes #50.

## Problem

When a table's `displayField` resolves to a column whose value is an enum (or any non-`Stringable` value object), `AuditLogBehavior` blows up the host save with:

```
Object of class App\Model\Enum\ProjectDocumentType could not be converted to string
in src/Model/Behavior/AuditLogBehavior.php on line 371
```

Three call sites all do the same naive cast:

```php
$displayValue = (string)$entity->get($displayField);
```

This fails for backed enums, unit enums, and any other object that doesn't implement `__toString()`. The error path that fired in #50 was `Table::save` → belongsToMany replace → cascade `afterDelete` on the junction → line 371. Cascade deletes hit the same bug at line 435, and a normal create/update via `createEvent()` at line 218 has the same shape.

## Fix

Extracted a single `extractDisplayValue()` helper that:

- returns `null` for composite (`array`) display fields, missing fields, or `null` values — same effective behavior as before for the common case
- maps `BackedEnum` → `->value`
- maps `UnitEnum` → `->name`
- handles scalars and `Stringable` instances
- returns `null` for anything else, so the audit row still gets written instead of breaking the host save

Three call sites — `createEvent()`, `afterDelete()`, `logCascadeDeletes()` — all funnel through it. No behavior change for string display fields.

## Tests

Added regression coverage for backed enum, unit enum, and `Stringable` display values on save, plus the cascade-style `afterDelete` path that triggered the issue.

## Quality gates

- `vendor/bin/phpunit` — 293 tests pass
- `vendor/bin/phpstan analyze` — clean
- `vendor/bin/phpcs` — clean

## Out of scope

Persister-side serialization of enum values inside `$changed` / `$original` arrays already works — `json_encode` natively handles `BackedEnum` since PHP 8.1. This PR is strictly the displayValue path.
