### PR TITLE
Fix pagination icons rendering as raw text in admin

### DIFF
--- a/templates/element/pagination.php
+++ b/templates/element/pagination.php
@@ -25,11 +25,11 @@ $this->Paginator->setTemplates([
 ?>
 <nav class="mt-3" aria-label="<?= __('Page navigation') ?>">
 	<ul class="pagination justify-content-center mb-2">
-		<?= $this->Paginator->first('<i class="fas fa-angle-double-left"></i>', ['escapeTitle' => false]) ?>
-		<?= $this->Paginator->prev('<i class="fas fa-angle-left"></i>', ['escapeTitle' => false]) ?>
+		<?= $this->Paginator->first('<i class="fas fa-angle-double-left"></i>', ['escape' => false]) ?>
+		<?= $this->Paginator->prev('<i class="fas fa-angle-left"></i>', ['escape' => false]) ?>
 		<?= $this->Paginator->numbers() ?>
-		<?= $this->Paginator->next('<i class="fas fa-angle-right"></i>', ['escapeTitle' => false]) ?>
-		<?= $this->Paginator->last('<i class="fas fa-angle-double-right"></i>', ['escapeTitle' => false]) ?>
+		<?= $this->Paginator->next('<i class="fas fa-angle-right"></i>', ['escape' => false]) ?>
+		<?= $this->Paginator->last('<i class="fas fa-angle-double-right"></i>', ['escape' => false]) ?>
 	</ul>
 	<p class="text-center text-muted small mb-0">
 		<?= $this->Paginator->counter(__('Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?>


### PR DESCRIPTION
## Summary

PR #46 switched the four Paginator nav links (\`first\` / \`prev\` / \`next\` / \`last\`) in \`templates/element/pagination.php\` from \`'escape' => false\` to \`'escapeTitle' => false\`. \`PaginatorHelper\` only honors \`escape\` — \`escapeTitle\` is silently ignored — so the title fell back to the default escaped path and the FontAwesome \`<i>\` tags rendered as literal HTML text in \`/admin/audit-logs\`.

## Fix

Revert those four to \`'escape' => false\`. Verified in CakePHP source: \`PaginatorHelper::prev/next/first/last/sort\` all use only the \`escape\` option, with no narrower title-only equivalent.

## After

Icons render correctly:

> ‹‹ ‹  Page 1 of 1, showing 5 record(s) out of 5 total  › ››