### PR TITLE
Fix doc bugs flagged in correctness audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ public function beforeFilter(EventInterface $event)
 {
     parent::beforeFilter($event);
 
+    $identity = $this->getRequest()->getAttribute('identity');
     EventManager::instance()->on(
         new RequestMetadata(
             request: $this->getRequest(),
-            user: $this->getRequest()->getAttribute('identity')?->getIdentifier(),
+            userId: $identity?->getIdentifier(),
+            userDisplay: $identity?->get('username'),
         ),
     );
 }

--- a/docs/gdpr.md
+++ b/docs/gdpr.md
@@ -71,8 +71,10 @@ What gets anonymized:
 | `user_id` | `123` | `anon_a1b2c3d4` |
 | `user_display` | `John Doe` | `ANONYMIZED` |
 | `meta.user` | `john@example.com` | `ANONYMIZED` |
-| `meta.ip` | `192.168.1.100` | `0.0.0.0` |
+| `meta.username` | `johndoe` | `ANONYMIZED` |
 | `meta.email` | `john@example.com` | `deleted@anonymized.local` |
+| `meta.ip` | `192.168.1.100` | `0.0.0.0` |
+| `meta.user_agent` | `Mozilla/5.0 ...` | `ANONYMIZED` |
 | `original.email` | `old@example.com` | `[REDACTED]` |
 | `changed.name` | `John Doe` | `[REDACTED]` |
 
@@ -225,8 +227,8 @@ Combine GDPR operations with retention policies for a complete data lifecycle:
     'retention' => [
         'default' => 90,        // Keep logs for 90 days
         'tables' => [
-            'users' => 365,     // Keep user logs for 1 year
-            'orders' => 2555,   // Keep order logs for 7 years (compliance)
+            'Users' => 365,     // Keep user logs for 1 year
+            'Orders' => 2555,   // Keep order logs for 7 years (compliance)
         ],
     ],
     'gdpr' => [

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -598,7 +598,7 @@ public function execute()
 
 ### Storing Reason in Database (Table Persister)
 
-If using the `TablePersister`, you can extract the reason to a dedicated database column:
+If using the `TablePersister`, you can extract the reason to a dedicated database column. `user_id` and `user_display` are auto-extracted to their dedicated columns out of the box, so only register here for additional custom fields:
 
 ```php
 // In your configuration (e.g., config/app_local.php or bootstrap.php)
@@ -606,7 +606,6 @@ $this->addBehavior('AuditStash.AuditLog');
 $this->behaviors()->get('AuditLog')->persister()->setConfig([
     'extractMetaFields' => [
         'reason' => 'reason', // Extract 'reason' from meta to 'reason' column
-        'user' => 'user_id',
     ],
 ]);
 ```
@@ -746,7 +745,7 @@ if ($success) {
     $this->Bookmarks->behaviors()->get('AuditLog')->afterCommit(
         $event,
         $result,
-        new ArrayObject($auditTrail->toSaveOptions()),
+        new ArrayObject($trail->toSaveOptions()),
     );
 }
 ```

--- a/docs/viewer.md
+++ b/docs/viewer.md
@@ -102,17 +102,17 @@ By default, the user value in audit logs is displayed as plain text. You can con
 ],
 ```
 
-Available placeholders: `{user}` (the linkable part), `{display}` (the display name), `{raw}` (original value).
+Available placeholders: `{user}` (the linkable part, populated from `user_id`), `{display}` (the display name, from `user_display`).
 
 **Callable (recommended for conditional linking):**
 
 ```php
 // In config/app.php
 'AuditStash' => [
-    'linkUser' => function ($id, $displayName, $raw) {
+    'linkUser' => function ($userId, $displayName) {
         // Only link numeric user IDs
-        if (is_numeric($id)) {
-            return '/admin/users/view/' . $id;
+        if (is_numeric($userId)) {
+            return '/admin/users/view/' . $userId;
         }
         // Return null to display without link
         return null;
@@ -134,42 +134,32 @@ Available placeholders: `{user}` (the linkable part), `{display}` (the display n
 ],
 ```
 
-#### Compound User Format (ID + Display Name)
+#### Storing User ID and Display Name
 
-You can store both a linkable ID and a display name in a single value using the compound format `id:displayName`:
+`RequestMetadata` keeps the linkable ID and the human-readable display name in two separate constructor arguments. They land in the dedicated `user_id` and `user_display` columns and feed the `{user}` and `{display}` placeholders independently:
 
 ```php
 // In your AppController
+$identity = $this->getRequest()->getAttribute('identity');
 EventManager::instance()->on(
     new RequestMetadata(
         request: $this->getRequest(),
-        user: $userId ? ($userId . ':' . $username) : null, // e.g., "123:john_doe"
+        userId: $identity?->getIdentifier(),
+        userDisplay: $identity?->get('username'),
     ),
 );
 ```
 
-With this format:
-- The **first part** (before `:`) is used for linking (`{user}` placeholder)
-- The **second part** (after `:`) is displayed to users (`{display}` placeholder)
-
-```php
-// Example: user value "456:Jane Smith"
-'AuditStash' => [
-    'linkUser' => '/admin/users/view/{user}', // Links to /admin/users/view/456
-],
-// Displays: <a href="/admin/users/view/456">Jane Smith</a>
-```
-
-To use a different separator (e.g., if usernames contain `:`):
+With `linkUser` configured:
 
 ```php
 'AuditStash' => [
-    'userSeparator' => '|', // Use pipe instead of colon
-    'linkUser' => '/admin/users/view/{user}',
+    'linkUser' => '/admin/users/view/{user}', // {user} = userId, e.g. /admin/users/view/456
 ],
-
-// Then store as: "456|Jane Smith"
+// Renders: <a href="/admin/users/view/456">Jane Smith</a>  (display = userDisplay)
 ```
+
+`userDisplay` is optional — when omitted, the helper falls back to a `User #<id>` label for numeric / UUID ids or shows the raw `userId` for string identifiers (usernames, emails).
 
 ### Linking Records to Backend
 

--- a/src/Model/Behavior/AuditLogBehavior.php
+++ b/src/Model/Behavior/AuditLogBehavior.php
@@ -472,6 +472,12 @@ class AuditLogBehavior extends Behavior
 
             /** @var \AuditStash\PersisterInterface $instance */
             $instance = new $class(compact('index', 'type'));
+
+            $persisterConfig = Configure::read('AuditStash.persisterConfig');
+            if (is_array($persisterConfig) && $persisterConfig && method_exists($instance, 'setConfig')) {
+                $instance->setConfig($persisterConfig);
+            }
+
             $persister = $instance;
         }
 

--- a/tests/TestCase/Model/Behavior/AuditLogBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/AuditLogBehaviorTest.php
@@ -9,6 +9,7 @@ use AuditStash\Event\AuditCreateEvent;
 use AuditStash\Event\AuditDeleteEvent;
 use AuditStash\Event\AuditUpdateEvent;
 use AuditStash\Model\Behavior\AuditLogBehavior;
+use AuditStash\Persister\TablePersister;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\ORM\Entity;
@@ -217,6 +218,28 @@ class AuditLogBehaviorTest extends TestCase
             'afterCommit' => ['afterCommit'],
             'null' => [null],
         ];
+    }
+
+    /**
+     * `AuditStash.persisterConfig` (documented in app.example.php and
+     * docs/tamper-evidence.md) is applied to the lazily-built persister so
+     * settings like `hashChain` actually take effect via global config.
+     *
+     * @return void
+     */
+    public function testPersisterConfigIsAppliedFromGlobalConfig(): void
+    {
+        Configure::write('AuditStash.persisterConfig', ['hashChain' => true]);
+
+        try {
+            $behavior = new AuditLogBehavior($this->table);
+            $persister = $behavior->persister();
+
+            $this->assertInstanceOf(TablePersister::class, $persister);
+            $this->assertTrue($persister->getConfig('hashChain'));
+        } finally {
+            Configure::delete('AuditStash.persisterConfig');
+        }
     }
 
     public function testSensitiveFields(): void


### PR DESCRIPTION
Doc-correctness pass after a user reported `RequestMetadata(user: ...)` examples — verified each finding against source before editing.

## What's in the PR

### Doc bugs (correctness)

- **`README.md` + `docs/viewer.md`** — `RequestMetadata` constructor was already split into `userId` / `userDisplay`, but the README still showed `user:`. Fixed both, plus removed the orphaned **"Compound User Format"** section in `viewer.md` that documented an `id:displayName` string trick and a `userSeparator` config — neither of those exist in `src/` (the API was split before this section got cleaned up).
- **`docs/viewer.md`** — `linkUser` placeholder list claimed `{raw}` exists; only `{user}` and `{display}` are substituted in `AuditHelper::buildUserUrl()`. Callable signature was documented as `function ($id, $displayName, $raw)` but the helper passes only two args (`AuditHelper.php:512`).
- **`docs/gdpr.md`** —
  - Anonymization table only listed 3 of the 5 default meta fields. Added `username` and `user_agent` to match `GdprService::$defaultAnonymizeFields`.
  - Retention example used lowercase `'users'` / `'orders'` for the table keys; `retention.md` correctly documents that these must match the `source` column verbatim (CamelCase). Capitalized.
- **`docs/usage.md`** —
  - `extractMetaFields` example mapped `'user' => 'user_id'`, but `user` is not a meta key written by `RequestMetadata`, and `user_id` / `user_display` are auto-extracted by `ExtractionTrait` already. Removed the misleading entry, kept the `reason` example, and added a one-liner clarifying the auto-extraction.
  - Fixed `$auditTrail` → `$trail` typo in the transactional example (the variable is named `$trail` two lines above).

### Code fix paired with `tamper-evidence.md`

`AuditStash.persisterConfig` is documented in `docs/tamper-evidence.md`, advertised in `config/app.example.php`, and even referenced verbatim in the `TablePersister` "missing migration" error message — but nothing in `src/` actually read it. Setting `persisterConfig.hashChain = true` via global config silently did nothing.

Wired it up in `AuditLogBehavior::persister()`: when the lazy persister is built, `Configure::read('AuditStash.persisterConfig')` is now applied via `setConfig()` if it's a non-empty array. This makes the documented behavior real without needing per-table `behaviors()->get('AuditLog')->persister()->setConfig(...)` boilerplate. Test added.

## Out of scope (deliberately not in this PR)

The audit also surfaced **completeness gaps** — public API with no docs at all. Not fixing in this PR to keep it reviewable; happy to land them as follow-ups if you'd like:

- `Audit::log()` / `Audit::setPersister()` static facade has only the README teaser, no parameter reference or hash-chain interaction notes.
- `RevertService` / `StateReconstructorService` / the revert-restore controller actions and templates have **no doc page at all** despite being a major feature.
- `AuditHelper` API beyond `formatUser` / `formatRecord` (badge, timeline, diff, revert/restore buttons) is undocumented.
- `AuditStash.adminLayout` config key is in `app.example.php` but not in `viewer.md` / `configuration.md`.
- `AuditStash.afterLog` event hook is undocumented.

## Quality gates

- `vendor/bin/phpunit` — 306 tests pass
- `vendor/bin/phpstan analyze` — clean
- `vendor/bin/phpcs` — clean
