### PR TITLE
Add forensic capture, sensitive-field rule, test assertions trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,31 @@ For Elasticsearch tests, set the environment variable:
 ```bash
 elastic_dsn="Cake\ElasticSearch\Datasource\Connection://127.0.0.1:9200?driver=Cake\ElasticSearch\Datasource\Connection" vendor/bin/phpunit
 ```
+
+### Asserting audit logs in your own tests
+
+Mix `AuditStash\TestSuite\AuditAssertionsTrait` into any `TestCase` that
+loads `plugin.AuditStash.AuditLogs` to assert on what was actually persisted:
+
+```php
+use AuditStash\TestSuite\AuditAssertionsTrait;
+
+class ArticlesControllerTest extends TestCase
+{
+    use AuditAssertionsTrait;
+
+    protected array $fixtures = ['plugin.AuditStash.AuditLogs', 'app.Articles'];
+
+    public function testArticleCreateIsAudited(): void
+    {
+        $this->post('/articles/add', ['title' => 'Hello']);
+
+        $this->assertAuditLogged('Articles', 'create');
+        $this->assertAuditFieldChanged('Articles', 'title', 'Hello');
+        $this->assertAuditCount(1, 'Articles');
+    }
+}
+```
+
+Available assertions: `assertAuditLogged()`, `assertAuditNotLogged()`,
+`assertAuditCount()`, `assertAuditFieldChanged()`.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ through the same persister, hash chain, and viewer as entity events.
 - **[Retention](docs/retention.md)** - Automated log cleanup and retention policies
 - **[Monitoring](docs/monitoring.md)** - Real-time alerting for suspicious activities
 - **[Tamper-Evidence](docs/tamper-evidence.md)** - Optional SHA-256 hash chain for GoBD / SOX / HIPAA integrity
+- **[Testing](docs/testing.md)** - `AuditAssertionsTrait` for asserting audit logs in your own test suite
 
 ## Demo
 
@@ -196,4 +197,5 @@ class ArticlesControllerTest extends TestCase
 ```
 
 Available assertions: `assertAuditLogged()`, `assertAuditNotLogged()`,
-`assertAuditCount()`, `assertAuditFieldChanged()`.
+`assertAuditCount()`, `assertAuditFieldChanged()`. See [Testing
+Documentation](docs/testing.md) for full signatures and usage tips.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -40,6 +40,15 @@ Enable monitoring and configure rules in your `config/app.php` or `config/app_lo
                 'severity' => 'medium',
                 'channels' => ['log', 'email'],
             ],
+
+            // Alert when sensitive fields are touched
+            'sensitive_fields' => [
+                'class' => \AuditStash\Monitor\Rule\SensitiveFieldRule::class,
+                'tables' => ['Users', 'ApiKeys'],         // Optional; empty = all sources
+                'fields' => ['password', 'role', 'two_factor_secret', 'api_token'],
+                'severity' => 'high',
+                'channels' => ['log', 'email'],
+            ],
         ],
 
         // Configure notification channels
@@ -94,6 +103,28 @@ Detects activity outside normal business hours.
   - 1 = Monday, 7 = Sunday
 - `tables` (array): Specific tables to monitor (optional)
 - `severity` (string): Alert severity level (default: 'medium')
+
+### SensitiveFieldRule
+
+Detects modifications to fields that you've flagged as sensitive (passwords, tokens, role assignments, etc.). Looks at the `changed` payload for create / update events and at `original` for deletes, so password rotations and API-key revocations both fire.
+
+**Configuration options:**
+- `fields` (array, required): Field names to flag. Empty means "no sensitive fields configured" — the rule never matches.
+- `tables` (array): Restrict to these source tables. Empty (default) matches any source.
+- `severity` (string): Alert severity level (default: 'high')
+
+**Example:**
+```php
+'sensitive_fields' => [
+    'class' => \AuditStash\Monitor\Rule\SensitiveFieldRule::class,
+    'tables' => ['Users'],
+    'fields' => ['password', 'role', 'email'],
+    'severity' => 'high',
+    'channels' => ['email', 'webhook'],
+],
+```
+
+The alert message lists the matched fields and the alert context includes both `matched_fields` and `configured_fields`, so downstream channels can render which sensitive field actually fired.
 
 ## Available Channels
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,108 @@
+# Testing Audit Logs
+
+The plugin ships a small assertions trait so your own test suite can verify what was actually persisted to `audit_logs` after an action — not just what an in-memory event queue produced.
+
+## Setup
+
+Mix `AuditStash\TestSuite\AuditAssertionsTrait` into any `TestCase` and load the `plugin.AuditStash.AuditLogs` fixture alongside whatever fixtures your test needs:
+
+```php
+use AuditStash\TestSuite\AuditAssertionsTrait;
+use Cake\TestSuite\TestCase;
+
+class ArticlesControllerTest extends TestCase
+{
+    use AuditAssertionsTrait;
+
+    protected array $fixtures = [
+        'plugin.AuditStash.AuditLogs',
+        'app.Articles',
+    ];
+
+    public function testArticleCreateIsAudited(): void
+    {
+        $this->post('/articles/add', ['title' => 'Hello']);
+
+        $this->assertAuditLogged('Articles', 'create');
+        $this->assertAuditFieldChanged('Articles', 'title', 'Hello');
+        $this->assertAuditCount(1, 'Articles');
+    }
+}
+```
+
+The trait queries the `audit_logs` table directly through `AuditStash.AuditLogs`, so it works the same for controller integration tests, table-level unit tests, and any `Audit::log()` custom-event call.
+
+> [!NOTE]
+> The trait is unrelated to the `AuditStash.AuditLog` *behavior* — it doesn't add or wire anything. It only reads. Tests that don't load the `AuditLogs` fixture will fail on the first assertion with a missing-table error.
+
+## Available assertions
+
+### `assertAuditLogged(string $source, ?string $type = null, string $message = '')`
+
+Passes when at least one row exists for `$source` (and, if given, `$type` — `create` / `update` / `delete` / any custom string from `Audit::log()`).
+
+```php
+$this->assertAuditLogged('Articles');                  // any event on Articles
+$this->assertAuditLogged('Articles', 'create');        // a create on Articles
+$this->assertAuditLogged('Users', 'user.login');       // a custom 'user.login' on Users
+```
+
+### `assertAuditNotLogged(string $source, ?string $type = null, string $message = '')`
+
+Inverse of `assertAuditLogged()`. Use to confirm an action did *not* trigger a row — useful when testing blacklist / whitelist behavior config:
+
+```php
+// `created` / `modified` are blacklisted by default — touching them alone
+// must not create an audit row.
+$article->modified = new DateTime();
+$this->Articles->save($article);
+
+$this->assertAuditNotLogged('Articles');
+```
+
+### `assertAuditCount(int $expected, ?string $source = null, string $message = '')`
+
+Exact-count assertion. Without `$source`, counts every row in `audit_logs`:
+
+```php
+$this->assertAuditCount(0);                  // no audit rows at all
+$this->assertAuditCount(3, 'Articles');      // exactly 3 rows for Articles
+$this->assertAuditCount(1, 'Users');         // exactly one Users event
+```
+
+Pair with `setUp()` that truncates the table (or the standard fixture rollback) to make the assertion meaningful.
+
+### `assertAuditFieldChanged(string $source, string $field, mixed $expectedValue = null, string $message = '')`
+
+Targets the **most recent** row for `$source` and checks that `$field` appears in the row's `changed` payload. With `$expectedValue` supplied, also asserts the changed-to value with `assertSame()`:
+
+```php
+$this->put('/articles/edit/1', ['title' => 'Renamed', 'body' => 'New body']);
+
+$this->assertAuditFieldChanged('Articles', 'title');                 // field present
+$this->assertAuditFieldChanged('Articles', 'title', 'Renamed');      // field == value
+```
+
+The "most recent" lookup uses `id DESC`, which matches insertion order under `TablePersister`. For a multi-event sequence where you need to assert on a specific earlier row, query `AuditStash.AuditLogs` directly with your own conditions.
+
+> [!NOTE]
+> This only inspects `changed`. For `delete` events the relevant payload lives under `original`; query the table directly when you need that.
+
+## Custom assertions
+
+The trait deliberately exposes a small surface so you can compose richer assertions without wrapping a different table query each time. The base query builder is `protected`:
+
+```php
+$rowsForUser = $this->buildAuditQuery('Articles', 'update')
+    ->where(['user_id' => '42'])
+    ->all();
+
+$this->assertCount(2, $rowsForUser);
+```
+
+## Tips
+
+- **`assertAuditLogged()` before `assertAuditFieldChanged()`** in the same test makes the failure mode obvious — if no row was logged at all, `assertAuditFieldChanged()` reports a less helpful "field not in changed payload of latest row" message.
+- **Truncate per test** if your suite shares the audit table across cases — CakePHP's standard fixture rollback handles this when you list the fixture explicitly.
+- **Combine with the `Audit::log()` facade** — custom events show up in the same table, so the same assertions verify them: `assertAuditLogged('Users', 'user.login')` works for events emitted via `Audit::log(type: 'user.login', ...)`.
+- **Use `assertAuditNotLogged()` to verify blacklists** — if your `AuditLog` behavior config blacklists `last_seen_at`, write a test that updates only that field and asserts no row was created.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -375,6 +375,25 @@ API requests are detected by:
 - URL path starting with `/api/`
 - `Authorization` header with `Bearer` or `Basic` prefix
 
+### Capturing forensic request fields
+
+`EnvironmentMetadata` can also pull a small set of request-derived fields into `meta`. They are off by default — these fields can carry PII / fingerprintable data and may have GDPR implications, so consumers must opt in explicitly via `capture`:
+
+```php
+EventManager::instance()->on(new EnvironmentMetadata(
+    request: $this->getRequest(),
+    capture: ['user_agent', 'referer', 'session_id'],
+));
+```
+
+Supported `capture` values:
+
+- `user_agent` — `User-Agent` header
+- `referer` — `Referer` header
+- `session_id` — PHP session id; only included when a session has actually been started (CLI, queue workers, and anonymous API hits silently skip it)
+
+Empty headers and unknown field names are filtered out so a typo can't smuggle arbitrary values into `meta`. `capture` is a no-op when no `request` is supplied (CLI / queue context).
+
 ### Combining with RequestMetadata
 
 You can use both listeners together:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -639,6 +639,101 @@ $table->addColumn('reason', 'text', [
 ]);
 ```
 
+## Tracking File Uploads (Hashes, not Content)
+
+Audited tables that store file content directly (binary blobs, base64 payloads, raw `UploadedFile` objects in a virtual field) cause two problems for the audit trail:
+
+- The audit row balloons to the size of the file — a 10 MB upload becomes a 10 MB `changed` payload, replicated for every save.
+- The audit table ends up holding sensitive content in plaintext, defeating the typical reason for separating uploads from primary tables.
+
+The fix is to make the entity field that the auditor sees be a **fingerprint** (hash + size + mime), not the raw content. Two ways to do that, depending on where the file lives in your model.
+
+### Approach 1: Computed virtual field on the entity
+
+If the file is uploaded to disk on save and the table only stores a path, expose a small "fingerprint" field that the auditor will pick up via the standard whitelist:
+
+```php
+// src/Model/Entity/Document.php
+namespace App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+class Document extends Entity
+{
+    protected array $_virtual = ['file_fingerprint'];
+
+    protected function _getFileFingerprint(): ?string
+    {
+        if ($this->file_path === null || !is_file($this->file_path)) {
+            return null;
+        }
+
+        return sprintf(
+            'sha256:%s size:%d mime:%s',
+            hash_file('sha256', $this->file_path),
+            filesize($this->file_path),
+            mime_content_type($this->file_path) ?: 'application/octet-stream',
+        );
+    }
+}
+```
+
+Then whitelist the virtual field in your behavior config so the audit picks it up alongside the real columns:
+
+```php
+// src/Model/Table/DocumentsTable.php
+$this->addBehavior('AuditStash.AuditLog', [
+    'whitelist' => ['title', 'file_path', 'file_fingerprint'],
+]);
+```
+
+A re-upload of the *same bytes* produces the same fingerprint → no audit row (assuming `ignoreEmpty` defaults). A re-upload of *different* bytes produces a different fingerprint → audit row showing `sha256:abc... → sha256:def...` with no file content stored.
+
+### Approach 2: Transform via the `AuditStash.beforeLog` event
+
+When the file content is already in a column you can't easily change (legacy schema, content stored as binary in the row), strip it at the audit boundary instead of at the model boundary. The `AuditStash.beforeLog` event fires once per save with all events for that transaction, and the listener can rewrite each event's payload before persistence:
+
+```php
+// in Application::bootstrap() or a dedicated listener
+EventManager::instance()->on(
+    'AuditStash.beforeLog',
+    function (EventInterface $event, array $logs): void {
+        foreach ($logs as $log) {
+            foreach (['changed', 'original'] as $side) {
+                $payload = $log->{'get' . ucfirst($side)}() ?? [];
+                if (isset($payload['file_blob']) && is_string($payload['file_blob'])) {
+                    $payload['file_blob'] = sprintf(
+                        'sha256:%s size:%d',
+                        hash('sha256', $payload['file_blob']),
+                        strlen($payload['file_blob']),
+                    );
+                }
+                if ($side === 'changed') {
+                    // BaseEvent has no public setter for changed/original, so this
+                    // approach requires either (a) an event subclass that exposes
+                    // setters, or (b) a custom persister wrapping the default one.
+                }
+            }
+        }
+    },
+);
+```
+
+> [!WARNING]
+> `BaseEvent` exposes `getChanged()` / `getOriginal()` but no public setters (the audit row is a value object). For Approach 2 to work end-to-end without a fork, wrap your persister: write a thin `PersisterInterface` decorator that walks each event, rebuilds it with the redacted payload, and forwards to the real persister. For most apps Approach 1 is simpler and avoids that detour.
+
+### Bonus: redact PII fields in the same hook
+
+The same `beforeLog` listener (or the `sensitive` behavior config) is the right place to redact non-file PII inputs (passport numbers, ID photos as data URIs, etc.) — keep the audit row showing *that* the field changed, but never *what* it was:
+
+```php
+// In your Table:
+$this->addBehavior('AuditStash.AuditLog', [
+    'sensitive' => ['passport_scan_b64', 'id_photo_b64'],
+]);
+// → values appear as '****' in changed/original.
+```
+
 ## Implementing Your Own Persister Strategies
 
 There are valid reasons for wanting to use a different persist engine for your audit logs. Luckily, this plugin allows you to implement

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,7 @@ parameters:
 	ignoreErrors:
 		- identifier: missingType.iterableValue
 		- identifier: missingType.generics
+		# TestSuite traits are consumed by downstream apps' test cases, not by this package's own src/.
+		-
+			identifier: trait.unused
+			path: src/TestSuite/*

--- a/src/Meta/EnvironmentMetadata.php
+++ b/src/Meta/EnvironmentMetadata.php
@@ -17,6 +17,15 @@ use Cake\Http\ServerRequest;
  * - 'api' - API request (based on Accept header or URL pattern)
  * - 'queue' - Queue worker (when explicitly set)
  *
+ * Optionally captures request-derived forensic fields when a request is
+ * provided and the field is opted into via `capture`:
+ * - 'user_agent' - User-Agent header
+ * - 'referer' - Referer header
+ * - 'session_id' - PHP session id (only included if a session is active)
+ *
+ * These are off by default — they often contain PII / fingerprintable data
+ * and may have GDPR implications, so consumers must opt in explicitly.
+ *
  * Usage in Application.php or bootstrap:
  *
  * ```php
@@ -31,10 +40,23 @@ use Cake\Http\ServerRequest;
  *     'deployment' => 'production',
  *     'server' => gethostname(),
  * ]));
+ *
+ * // Capture forensic fields from the request
+ * EventManager::instance()->on(new EnvironmentMetadata(
+ *     request: $this->getRequest(),
+ *     capture: ['user_agent', 'referer', 'session_id'],
+ * ));
  * ```
  */
 class EnvironmentMetadata implements EventListenerInterface
 {
+    /**
+     * Request-derived fields that can be opted into via `capture`.
+     *
+     * @var array<string>
+     */
+    public const SUPPORTED_CAPTURE_FIELDS = ['user_agent', 'referer', 'session_id'];
+
     /**
      * The request source type.
      */
@@ -53,20 +75,32 @@ class EnvironmentMetadata implements EventListenerInterface
     protected ?ServerRequest $request;
 
     /**
+     * Request-derived field names to capture into meta.
+     *
+     * @var array<string>
+     */
+    protected array $capture;
+
+    /**
      * Constructor.
      *
      * @param string|null $source Explicit source type, or null for auto-detection
      * @param array<string, mixed> $extraData Additional metadata to include
-     * @param \Cake\Http\ServerRequest|null $request Optional request for API detection
+     * @param \Cake\Http\ServerRequest|null $request Optional request for API detection / forensic capture
+     * @param array<string> $capture Request-derived fields to include in meta. Supported:
+     *   `user_agent`, `referer`, `session_id`. Ignored when `$request` is null.
+     *   Off by default because these fields can carry PII.
      */
     public function __construct(
         ?string $source = null,
         array $extraData = [],
         ?ServerRequest $request = null,
+        array $capture = [],
     ) {
         $this->request = $request;
         $this->extraData = $extraData;
         $this->source = $source ?? $this->detectSource();
+        $this->capture = array_values(array_intersect($capture, self::SUPPORTED_CAPTURE_FIELDS));
     }
 
     /**
@@ -91,11 +125,63 @@ class EnvironmentMetadata implements EventListenerInterface
     {
         $meta = [
             'request_source' => $this->source,
-        ] + $this->extraData;
+        ] + $this->captureRequestFields() + $this->extraData;
 
         foreach ($logs as $log) {
             $log->setMetaInfo($log->getMetaInfo() + $meta);
         }
+    }
+
+    /**
+     * Build the request-derived meta entries for the configured capture set.
+     * Skips fields that have no value (empty headers, no active session) so
+     * the audit row does not store useless empty strings.
+     *
+     * @return array<string, mixed>
+     */
+    protected function captureRequestFields(): array
+    {
+        if ($this->request === null || !$this->capture) {
+            return [];
+        }
+
+        $captured = [];
+        foreach ($this->capture as $field) {
+            $value = match ($field) {
+                'user_agent' => $this->request->getHeaderLine('User-Agent'),
+                'referer' => $this->request->getHeaderLine('Referer'),
+                'session_id' => $this->resolveSessionId(),
+                default => '',
+            };
+
+            if ($value !== '' && $value !== null) {
+                $captured[$field] = $value;
+            }
+        }
+
+        return $captured;
+    }
+
+    /**
+     * Returns the active session id, or null when no session has been started
+     * (CLI requests, queue workers, anonymous API hits).
+     *
+     * @return string|null
+     */
+    protected function resolveSessionId(): ?string
+    {
+        if ($this->request === null) {
+            return null;
+        }
+
+        $session = $this->request->getSession();
+        if (!$session->started()) {
+            return null;
+        }
+
+        $id = $session->id();
+
+        return $id !== '' ? $id : null;
     }
 
     /**

--- a/src/Monitor/Rule/SensitiveFieldRule.php
+++ b/src/Monitor/Rule/SensitiveFieldRule.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\Monitor\Rule;
+
+use AuditStash\AuditLogType;
+use AuditStash\Model\Entity\AuditLog;
+
+/**
+ * Rule to detect modifications to sensitive fields.
+ *
+ * Triggers when an audit log touches any of the configured fields on any of
+ * the configured tables. For Create events the fields are looked up in the
+ * `changed` payload, for Delete events in `original`, and for Update events
+ * in either side.
+ *
+ * Configuration:
+ * - `fields` (array, required): field names that are considered sensitive.
+ *   The rule never matches when this is empty — empty means "no sensitive
+ *   fields configured", not "match everything".
+ * - `tables` (array, optional): restrict matching to these source tables.
+ *   When empty (default) the rule matches any source.
+ * - `severity` (string, optional): defaults to `high`.
+ *
+ * ```php
+ * 'AuditStash.monitor.rules' => [
+ *     [
+ *         'class' => SensitiveFieldRule::class,
+ *         'config' => [
+ *             'tables' => ['Users', 'ApiKeys'],
+ *             'fields' => ['password', 'role', 'two_factor_secret', 'api_token'],
+ *             'severity' => 'high',
+ *         ],
+ *     ],
+ * ],
+ * ```
+ */
+class SensitiveFieldRule extends AbstractRule
+{
+    /**
+     * @inheritDoc
+     */
+    public function matches(AuditLog $auditLog): bool
+    {
+        $fields = (array)$this->getConfig('fields', []);
+        if (!$fields) {
+            return false;
+        }
+
+        $tables = (array)$this->getConfig('tables', []);
+        if ($tables && !in_array($auditLog->source, $tables, true)) {
+            return false;
+        }
+
+        return (bool)$this->matchedFields($auditLog, $fields);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSeverity(): string
+    {
+        return (string)$this->getConfig('severity', 'high');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMessage(AuditLog $auditLog): string
+    {
+        $fields = (array)$this->getConfig('fields', []);
+        $matched = $this->matchedFields($auditLog, $fields);
+
+        return sprintf(
+            'Sensitive field(s) %s modified on %s (%s)',
+            implode(', ', $matched),
+            $auditLog->source,
+            $auditLog->type,
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getContext(AuditLog $auditLog): array
+    {
+        $fields = (array)$this->getConfig('fields', []);
+
+        return [
+            'table' => $auditLog->source,
+            'event_type' => $auditLog->type,
+            'matched_fields' => $this->matchedFields($auditLog, $fields),
+            'configured_fields' => $fields,
+        ];
+    }
+
+    /**
+     * Returns the configured field names that actually appear in the row's
+     * `changed` / `original` payload, depending on event type.
+     *
+     * @param \AuditStash\Model\Entity\AuditLog $auditLog
+     * @param array<string> $fields Configured sensitive field names
+     *
+     * @return array<string>
+     */
+    protected function matchedFields(AuditLog $auditLog, array $fields): array
+    {
+        $payloadKeys = $this->payloadKeys($auditLog);
+        if (!$payloadKeys) {
+            return [];
+        }
+
+        return array_values(array_intersect($fields, $payloadKeys));
+    }
+
+    /**
+     * Collects the field names present in the relevant side of the row's
+     * payload for this event type. Tolerates string-encoded JSON for rows
+     * read with non-default hydration (defensive — `AuditLogsTable` casts
+     * these columns to `json` so we usually get arrays).
+     *
+     * @param \AuditStash\Model\Entity\AuditLog $auditLog
+     *
+     * @return array<string>
+     */
+    protected function payloadKeys(AuditLog $auditLog): array
+    {
+        $sides = match ($auditLog->type) {
+            AuditLogType::Create->value => ['changed'],
+            AuditLogType::Delete->value => ['original'],
+            default => ['changed', 'original'],
+        };
+
+        $keys = [];
+        foreach ($sides as $side) {
+            $payload = $auditLog->get($side);
+            if (is_string($payload) && $payload !== '') {
+                $decoded = json_decode($payload, true);
+                $payload = is_array($decoded) ? $decoded : null;
+            }
+
+            if (is_array($payload)) {
+                $keys = array_merge($keys, array_keys($payload));
+            }
+        }
+
+        return array_values(array_unique($keys));
+    }
+}

--- a/src/TestSuite/AuditAssertionsTrait.php
+++ b/src/TestSuite/AuditAssertionsTrait.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\TestSuite;
+
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\ORM\Query\SelectQuery;
+
+/**
+ * Test assertions for the audit_logs table.
+ *
+ * Mix into any `TestCase` that exercises behavior wired through the
+ * `AuditStash.AuditLog` behavior (or the `Audit::log()` facade) and that
+ * loads the `plugin.AuditStash.AuditLogs` fixture. The assertions query the
+ * `audit_logs` table directly, so they verify what was actually persisted —
+ * not just what an in-memory event queue produced.
+ *
+ * ```php
+ * use AuditStash\TestSuite\AuditAssertionsTrait;
+ * use Cake\TestSuite\TestCase;
+ *
+ * class ArticlesControllerTest extends TestCase
+ * {
+ *     use AuditAssertionsTrait;
+ *
+ *     protected array $fixtures = ['plugin.AuditStash.AuditLogs', 'app.Articles'];
+ *
+ *     public function testArticleCreateIsAudited(): void
+ *     {
+ *         $this->post('/articles/add', ['title' => 'Hello']);
+ *
+ *         $this->assertAuditLogged('Articles', 'create');
+ *         $this->assertAuditFieldChanged('Articles', 'title', 'Hello');
+ *         $this->assertAuditCount(1, 'Articles');
+ *     }
+ * }
+ * ```
+ */
+trait AuditAssertionsTrait
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Assert that at least one audit log row exists for the given source
+     * (and optionally a specific event type — `create`, `update`, `delete`,
+     * or any custom string).
+     *
+     * @param string $source The audit source / table alias (e.g. 'Articles')
+     * @param string|null $type Event type to match. `null` matches any type.
+     * @param string $message Optional failure message
+     *
+     * @return void
+     */
+    public function assertAuditLogged(string $source, ?string $type = null, string $message = ''): void
+    {
+        $count = $this->buildAuditQuery($source, $type)->count();
+
+        $description = $type !== null
+            ? sprintf('audit log for source "%s" of type "%s"', $source, $type)
+            : sprintf('audit log for source "%s"', $source);
+
+        $this->assertGreaterThan(
+            0,
+            $count,
+            $message !== '' ? $message : sprintf('Expected at least one %s, got none.', $description),
+        );
+    }
+
+    /**
+     * Inverse of `assertAuditLogged()`. Use to confirm that an action did
+     * NOT trigger any audit row for a given source.
+     *
+     * @param string $source The audit source / table alias
+     * @param string|null $type Event type to match. `null` matches any type.
+     * @param string $message Optional failure message
+     *
+     * @return void
+     */
+    public function assertAuditNotLogged(string $source, ?string $type = null, string $message = ''): void
+    {
+        $count = $this->buildAuditQuery($source, $type)->count();
+
+        $description = $type !== null
+            ? sprintf('audit log for source "%s" of type "%s"', $source, $type)
+            : sprintf('audit log for source "%s"', $source);
+
+        $this->assertSame(
+            0,
+            $count,
+            $message !== '' ? $message : sprintf('Expected no %s, got %d.', $description, $count),
+        );
+    }
+
+    /**
+     * Assert the exact number of audit rows. With `$source = null`, counts
+     * every row in the table (useful for "no audit logs at all" checks).
+     *
+     * @param int $expected Expected row count
+     * @param string|null $source If given, restrict to this source
+     * @param string $message Optional failure message
+     *
+     * @return void
+     */
+    public function assertAuditCount(int $expected, ?string $source = null, string $message = ''): void
+    {
+        $count = $this->buildAuditQuery($source, null)->count();
+
+        $this->assertSame(
+            $expected,
+            $count,
+            $message !== '' ? $message : sprintf(
+                'Expected %d audit log(s)%s, got %d.',
+                $expected,
+                $source !== null ? ' for source "' . $source . '"' : '',
+                $count,
+            ),
+        );
+    }
+
+    /**
+     * Assert that the most recent audit row for the given source has the
+     * specified field present in its `changed` payload. Optionally also
+     * assert the changed-to value.
+     *
+     * Looks at `changed` (which covers `create` and `update` events). For
+     * `delete` events use `assertAuditFieldRemoved()`.
+     *
+     * @param string $source The audit source / table alias
+     * @param string $field Field name expected in `changed`
+     * @param mixed $expectedValue Optional expected value. Use `null` to skip the value check.
+     * @param string $message Optional failure message
+     *
+     * @return void
+     */
+    public function assertAuditFieldChanged(
+        string $source,
+        string $field,
+        mixed $expectedValue = null,
+        string $message = '',
+    ): void {
+        $log = $this->buildAuditQuery($source, null)
+            ->orderByDesc('id')
+            ->first();
+
+        $this->assertNotNull(
+            $log,
+            $message !== '' ? $message : sprintf('No audit log found for source "%s".', $source),
+        );
+
+        /** @var array<string, mixed>|null $changed */
+        $changed = $log->get('changed');
+        $changed = is_array($changed) ? $changed : [];
+
+        $this->assertArrayHasKey(
+            $field,
+            $changed,
+            $message !== '' ? $message : sprintf(
+                'Expected field "%s" in changed payload of latest audit row for "%s". Present fields: %s.',
+                $field,
+                $source,
+                $changed ? implode(', ', array_keys($changed)) : '<none>',
+            ),
+        );
+
+        if (func_num_args() >= 3) {
+            $this->assertSame(
+                $expectedValue,
+                $changed[$field],
+                $message !== '' ? $message : sprintf(
+                    'Field "%s" in latest audit row for "%s" did not match expected value.',
+                    $field,
+                    $source,
+                ),
+            );
+        }
+    }
+
+    /**
+     * Build the base audit-log query used by the assertions.
+     *
+     * @param string|null $source Source filter, or null to match any source
+     * @param string|null $type Event type filter, or null to match any type
+     *
+     * @return \Cake\ORM\Query\SelectQuery
+     */
+    protected function buildAuditQuery(?string $source, ?string $type): SelectQuery
+    {
+        $conditions = [];
+        if ($source !== null) {
+            $conditions['source'] = $source;
+        }
+        if ($type !== null) {
+            $conditions['type'] = $type;
+        }
+
+        $query = $this->fetchTable('AuditStash.AuditLogs')->find();
+        if ($conditions) {
+            $query->where($conditions);
+        }
+
+        return $query;
+    }
+}

--- a/tests/TestCase/Meta/EnvironmentMetadataTest.php
+++ b/tests/TestCase/Meta/EnvironmentMetadataTest.php
@@ -209,4 +209,148 @@ class EnvironmentMetadataTest extends TestCase
         $this->assertArrayHasKey('AuditStash.beforeLog', $events);
         $this->assertSame('beforeLog', $events['AuditStash.beforeLog']);
     }
+
+    /**
+     * Capture is opt-in: omitting `capture` keeps the legacy meta payload.
+     *
+     * @return void
+     */
+    public function testCaptureDefaultsToOff(): void
+    {
+        $request = new ServerRequest([
+            'environment' => ['HTTP_USER_AGENT' => 'Mozilla/5.0 ...'],
+        ]);
+
+        $metadata = new EnvironmentMetadata('web', [], $request);
+
+        $log = new AuditCreateEvent('tx-1', 1, 'articles', [], [], null);
+        $metadata->beforeLog(new Event('AuditStash.beforeLog'), [$log]);
+
+        $meta = $log->getMetaInfo();
+        $this->assertSame(['request_source' => 'web'], $meta);
+    }
+
+    /**
+     * Opting into `user_agent` and `referer` adds the matching headers.
+     *
+     * @return void
+     */
+    public function testCaptureUserAgentAndReferer(): void
+    {
+        $request = new ServerRequest([
+            'environment' => [
+                'HTTP_USER_AGENT' => 'Mozilla/5.0 (X11; Linux) Firefox/123',
+                'HTTP_REFERER' => 'https://example.com/admin/articles',
+            ],
+        ]);
+
+        $metadata = new EnvironmentMetadata(
+            source: 'web',
+            request: $request,
+            capture: ['user_agent', 'referer'],
+        );
+
+        $log = new AuditCreateEvent('tx-2', 1, 'articles', [], [], null);
+        $metadata->beforeLog(new Event('AuditStash.beforeLog'), [$log]);
+
+        $meta = $log->getMetaInfo();
+        $this->assertSame('Mozilla/5.0 (X11; Linux) Firefox/123', $meta['user_agent']);
+        $this->assertSame('https://example.com/admin/articles', $meta['referer']);
+    }
+
+    /**
+     * Empty headers (no Referer at all on a direct hit) must NOT pollute the
+     * audit row with empty strings.
+     *
+     * @return void
+     */
+    public function testCaptureSkipsEmptyHeaders(): void
+    {
+        $request = new ServerRequest([
+            'environment' => ['HTTP_USER_AGENT' => 'curl/8.0'],
+        ]);
+
+        $metadata = new EnvironmentMetadata(
+            source: 'web',
+            request: $request,
+            capture: ['user_agent', 'referer'],
+        );
+
+        $log = new AuditCreateEvent('tx-3', 1, 'articles', [], [], null);
+        $metadata->beforeLog(new Event('AuditStash.beforeLog'), [$log]);
+
+        $meta = $log->getMetaInfo();
+        $this->assertSame('curl/8.0', $meta['user_agent']);
+        $this->assertArrayNotHasKey('referer', $meta);
+    }
+
+    /**
+     * Unknown capture field names are silently filtered out so a typo in
+     * userland config can't smuggle arbitrary values into meta.
+     *
+     * @return void
+     */
+    public function testCaptureFiltersUnknownFields(): void
+    {
+        $request = new ServerRequest([
+            'environment' => ['HTTP_USER_AGENT' => 'curl/8.0'],
+        ]);
+
+        $metadata = new EnvironmentMetadata(
+            source: 'web',
+            request: $request,
+            capture: ['user_agent', 'totally_unsupported'],
+        );
+
+        $log = new AuditCreateEvent('tx-4', 1, 'articles', [], [], null);
+        $metadata->beforeLog(new Event('AuditStash.beforeLog'), [$log]);
+
+        $meta = $log->getMetaInfo();
+        $this->assertSame('curl/8.0', $meta['user_agent']);
+        $this->assertArrayNotHasKey('totally_unsupported', $meta);
+    }
+
+    /**
+     * Without an active session the session_id capture must yield nothing
+     * rather than an empty string.
+     *
+     * @return void
+     */
+    public function testCaptureSessionIdSkippedWhenNotStarted(): void
+    {
+        $request = new ServerRequest([
+            'environment' => ['HTTP_USER_AGENT' => 'curl/8.0'],
+        ]);
+
+        $metadata = new EnvironmentMetadata(
+            source: 'web',
+            request: $request,
+            capture: ['session_id'],
+        );
+
+        $log = new AuditCreateEvent('tx-5', 1, 'articles', [], [], null);
+        $metadata->beforeLog(new Event('AuditStash.beforeLog'), [$log]);
+
+        $meta = $log->getMetaInfo();
+        $this->assertArrayNotHasKey('session_id', $meta);
+    }
+
+    /**
+     * `capture` is a no-op when no request is supplied (CLI / queue context).
+     *
+     * @return void
+     */
+    public function testCaptureIgnoredWithoutRequest(): void
+    {
+        $metadata = new EnvironmentMetadata(
+            source: 'cli',
+            capture: ['user_agent', 'referer'],
+        );
+
+        $log = new AuditCreateEvent('tx-6', 1, 'articles', [], [], null);
+        $metadata->beforeLog(new Event('AuditStash.beforeLog'), [$log]);
+
+        $meta = $log->getMetaInfo();
+        $this->assertSame(['request_source' => 'cli'], $meta);
+    }
 }

--- a/tests/TestCase/Monitor/Rule/SensitiveFieldRuleTest.php
+++ b/tests/TestCase/Monitor/Rule/SensitiveFieldRuleTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\Test\TestCase\Monitor\Rule;
+
+use AuditStash\AuditLogType;
+use AuditStash\Model\Entity\AuditLog;
+use AuditStash\Monitor\Rule\SensitiveFieldRule;
+use Cake\TestSuite\TestCase;
+
+class SensitiveFieldRuleTest extends TestCase
+{
+    public function testMatchesFieldChangedOnUpdate(): void
+    {
+        $rule = new SensitiveFieldRule([
+            'fields' => ['password', 'role'],
+        ]);
+
+        $log = new AuditLog([
+            'type' => AuditLogType::Update->value,
+            'source' => 'Users',
+            'changed' => ['role' => 'admin'],
+            'original' => ['role' => 'editor'],
+        ]);
+
+        $this->assertTrue($rule->matches($log));
+    }
+
+    public function testMatchesFieldPresentOnlyInOriginalForDelete(): void
+    {
+        $rule = new SensitiveFieldRule([
+            'fields' => ['api_token'],
+        ]);
+
+        $log = new AuditLog([
+            'type' => AuditLogType::Delete->value,
+            'source' => 'ApiKeys',
+            'changed' => null,
+            'original' => ['api_token' => 'secret', 'name' => 'CI'],
+        ]);
+
+        $this->assertTrue($rule->matches($log));
+    }
+
+    public function testMatchesFieldPresentInChangedOnCreate(): void
+    {
+        $rule = new SensitiveFieldRule([
+            'fields' => ['password'],
+        ]);
+
+        $log = new AuditLog([
+            'type' => AuditLogType::Create->value,
+            'source' => 'Users',
+            'changed' => ['username' => 'alice', 'password' => 'hashed'],
+            'original' => null,
+        ]);
+
+        $this->assertTrue($rule->matches($log));
+    }
+
+    public function testNoMatchWhenFieldAbsent(): void
+    {
+        $rule = new SensitiveFieldRule([
+            'fields' => ['password'],
+        ]);
+
+        $log = new AuditLog([
+            'type' => AuditLogType::Update->value,
+            'source' => 'Users',
+            'changed' => ['username' => 'bob'],
+            'original' => ['username' => 'bob_old'],
+        ]);
+
+        $this->assertFalse($rule->matches($log));
+    }
+
+    public function testNoMatchWhenFieldsConfigEmpty(): void
+    {
+        $rule = new SensitiveFieldRule([
+            'fields' => [],
+        ]);
+
+        $log = new AuditLog([
+            'type' => AuditLogType::Update->value,
+            'source' => 'Users',
+            'changed' => ['password' => 'x'],
+            'original' => ['password' => 'y'],
+        ]);
+
+        $this->assertFalse($rule->matches($log));
+    }
+
+    public function testTablesRestrictionFiltersOutOtherSources(): void
+    {
+        $rule = new SensitiveFieldRule([
+            'tables' => ['Users'],
+            'fields' => ['email'],
+        ]);
+
+        $log = new AuditLog([
+            'type' => AuditLogType::Update->value,
+            'source' => 'Profiles',
+            'changed' => ['email' => 'new@example.com'],
+            'original' => ['email' => 'old@example.com'],
+        ]);
+
+        $this->assertFalse($rule->matches($log));
+    }
+
+    public function testTablesRestrictionAllowsListedSource(): void
+    {
+        $rule = new SensitiveFieldRule([
+            'tables' => ['Users', 'Profiles'],
+            'fields' => ['email'],
+        ]);
+
+        $log = new AuditLog([
+            'type' => AuditLogType::Update->value,
+            'source' => 'Profiles',
+            'changed' => ['email' => 'new@example.com'],
+            'original' => ['email' => 'old@example.com'],
+        ]);
+
+        $this->assertTrue($rule->matches($log));
+    }
+
+    public function testStringEncodedJsonPayloadIsTolerated(): void
+    {
+        $rule = new SensitiveFieldRule([
+            'fields' => ['password'],
+        ]);
+
+        $log = new AuditLog([
+            'type' => AuditLogType::Update->value,
+            'source' => 'Users',
+        ]);
+        $log->set('changed', json_encode(['password' => 'hashed', 'username' => 'a']));
+        $log->set('original', json_encode(['password' => 'old', 'username' => 'a']));
+
+        $this->assertTrue($rule->matches($log));
+    }
+
+    public function testSeverityDefaultsToHigh(): void
+    {
+        $rule = new SensitiveFieldRule(['fields' => ['x']]);
+
+        $this->assertSame('high', $rule->getSeverity());
+    }
+
+    public function testSeverityIsConfigurable(): void
+    {
+        $rule = new SensitiveFieldRule(['fields' => ['x'], 'severity' => 'critical']);
+
+        $this->assertSame('critical', $rule->getSeverity());
+    }
+
+    public function testMessageNamesMatchedFields(): void
+    {
+        $rule = new SensitiveFieldRule(['fields' => ['password', 'role', 'unused']]);
+
+        $log = new AuditLog([
+            'type' => AuditLogType::Update->value,
+            'source' => 'Users',
+            'changed' => ['password' => 'x', 'role' => 'admin'],
+            'original' => ['password' => 'y', 'role' => 'editor'],
+        ]);
+
+        $message = $rule->getMessage($log);
+
+        $this->assertStringContainsString('password', $message);
+        $this->assertStringContainsString('role', $message);
+        $this->assertStringContainsString('Users', $message);
+        $this->assertStringNotContainsString('unused', $message);
+    }
+
+    public function testContextReportsMatchedAndConfiguredFields(): void
+    {
+        $rule = new SensitiveFieldRule([
+            'fields' => ['password', 'role'],
+        ]);
+
+        $log = new AuditLog([
+            'type' => AuditLogType::Update->value,
+            'source' => 'Users',
+            'changed' => ['password' => 'x'],
+            'original' => ['password' => 'y'],
+        ]);
+
+        $context = $rule->getContext($log);
+
+        $this->assertSame('Users', $context['table']);
+        $this->assertSame('update', $context['event_type']);
+        $this->assertSame(['password'], $context['matched_fields']);
+        $this->assertSame(['password', 'role'], $context['configured_fields']);
+    }
+}

--- a/tests/TestCase/TestSuite/AuditAssertionsTraitTest.php
+++ b/tests/TestCase/TestSuite/AuditAssertionsTraitTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\Test\TestCase\TestSuite;
+
+use AuditStash\AuditLogType;
+use AuditStash\TestSuite\AuditAssertionsTrait;
+use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\AssertionFailedError;
+
+class AuditAssertionsTraitTest extends TestCase
+{
+    use AuditAssertionsTrait;
+
+    protected array $fixtures = [
+        'plugin.AuditStash.AuditLogs',
+    ];
+
+    public function testAssertAuditLoggedPassesWhenRowExists(): void
+    {
+        $this->createLog('Articles', AuditLogType::Create->value, ['title' => 'Hello']);
+
+        $this->assertAuditLogged('Articles');
+        $this->assertAuditLogged('Articles', AuditLogType::Create->value);
+    }
+
+    public function testAssertAuditLoggedFailsWhenSourceMissing(): void
+    {
+        $error = $this->captureAssertionFailure(fn () => $this->assertAuditLogged('Articles'));
+
+        $this->assertStringContainsString('Articles', $error->getMessage());
+    }
+
+    public function testAssertAuditLoggedFailsWhenTypeDoesNotMatch(): void
+    {
+        $this->createLog('Articles', AuditLogType::Create->value);
+
+        $error = $this->captureAssertionFailure(
+            fn () => $this->assertAuditLogged('Articles', AuditLogType::Delete->value),
+        );
+
+        $this->assertStringContainsString('delete', $error->getMessage());
+    }
+
+    public function testAssertAuditNotLoggedPassesWhenAbsent(): void
+    {
+        $this->createLog('Articles', AuditLogType::Create->value);
+
+        $this->assertAuditNotLogged('Profiles');
+        $this->assertAuditNotLogged('Articles', AuditLogType::Delete->value);
+    }
+
+    public function testAssertAuditNotLoggedFailsWhenPresent(): void
+    {
+        $this->createLog('Articles', AuditLogType::Create->value);
+
+        $error = $this->captureAssertionFailure(fn () => $this->assertAuditNotLogged('Articles'));
+
+        $this->assertStringContainsString('Articles', $error->getMessage());
+    }
+
+    public function testAssertAuditCount(): void
+    {
+        $this->createLog('Articles', AuditLogType::Create->value);
+        $this->createLog('Articles', AuditLogType::Update->value);
+        $this->createLog('Profiles', AuditLogType::Create->value);
+
+        $this->assertAuditCount(3);
+        $this->assertAuditCount(2, 'Articles');
+        $this->assertAuditCount(1, 'Profiles');
+        $this->assertAuditCount(0, 'Unknown');
+    }
+
+    public function testAssertAuditCountFailureMessageMentionsActual(): void
+    {
+        $this->createLog('Articles', AuditLogType::Create->value);
+
+        $error = $this->captureAssertionFailure(fn () => $this->assertAuditCount(2, 'Articles'));
+
+        $this->assertStringContainsString('got 1', $error->getMessage());
+    }
+
+    public function testAssertAuditFieldChangedWithoutValueCheck(): void
+    {
+        $this->createLog('Articles', AuditLogType::Update->value, ['title' => 'New', 'body' => 'Body']);
+
+        $this->assertAuditFieldChanged('Articles', 'title');
+        $this->assertAuditFieldChanged('Articles', 'body');
+    }
+
+    public function testAssertAuditFieldChangedWithValueCheck(): void
+    {
+        $this->createLog('Articles', AuditLogType::Update->value, ['title' => 'Hello']);
+
+        $this->assertAuditFieldChanged('Articles', 'title', 'Hello');
+    }
+
+    public function testAssertAuditFieldChangedFailsWhenFieldAbsent(): void
+    {
+        $this->createLog('Articles', AuditLogType::Update->value, ['body' => 'Body']);
+
+        $error = $this->captureAssertionFailure(fn () => $this->assertAuditFieldChanged('Articles', 'title'));
+
+        $this->assertStringContainsString('title', $error->getMessage());
+    }
+
+    public function testAssertAuditFieldChangedFailsOnValueMismatch(): void
+    {
+        $this->createLog('Articles', AuditLogType::Update->value, ['title' => 'Actual']);
+
+        $error = $this->captureAssertionFailure(
+            fn () => $this->assertAuditFieldChanged('Articles', 'title', 'Expected'),
+        );
+
+        $this->assertNotSame('', $error->getMessage());
+    }
+
+    public function testAssertAuditFieldChangedLooksAtMostRecentRow(): void
+    {
+        // Two updates: assertion targets the latest one.
+        $this->createLog('Articles', AuditLogType::Update->value, ['title' => 'Older']);
+        $this->createLog('Articles', AuditLogType::Update->value, ['title' => 'Newer']);
+
+        $this->assertAuditFieldChanged('Articles', 'title', 'Newer');
+    }
+
+    /**
+     * Run the given callable and return the AssertionFailedError it raised,
+     * or fail the surrounding test if it didn't raise one. Lets us verify
+     * the failure-mode behavior of an assert*() method without tripping the
+     * `expectException must not be followed by assert*` lint rule.
+     *
+     * @param callable $callable
+     *
+     * @return \PHPUnit\Framework\AssertionFailedError
+     */
+    private function captureAssertionFailure(callable $callable): AssertionFailedError
+    {
+        try {
+            $callable();
+        } catch (AssertionFailedError $error) {
+            return $error;
+        }
+
+        $this->fail('Expected the callable to raise an AssertionFailedError, but none was raised.');
+    }
+
+    /**
+     * @param string $source
+     * @param string $type
+     * @param array<string, mixed>|null $changed
+     *
+     * @return void
+     */
+    private function createLog(string $source, string $type, ?array $changed = null): void
+    {
+        $table = $this->fetchTable('AuditStash.AuditLogs');
+        $entity = $table->newEntity([
+            'transaction_key' => bin2hex(random_bytes(8)),
+            'type' => $type,
+            'source' => $source,
+            'primary_key' => 1,
+            'changed' => $changed,
+        ]);
+
+        $table->saveOrFail($entity);
+    }
+}


### PR DESCRIPTION
Three independent observability additions from the issue #1 idea list, bundled because they're individually small, all opt-in / additive, and slot into existing extension points without infrastructure changes.

## What's in the PR

### 1. `EnvironmentMetadata` — opt-in forensic field capture

New `capture` constructor argument enriches `meta` with request-derived fields:

```php
EventManager::instance()->on(new EnvironmentMetadata(
    request: $this->getRequest(),
    capture: ['user_agent', 'referer', 'session_id'],
));
```

- Off by default — these fields can carry PII / fingerprintable data and may have GDPR implications.
- Empty headers and inactive sessions skipped → no empty-string columns in the audit row.
- Allow-listed against `SUPPORTED_CAPTURE_FIELDS` so a typo can't smuggle arbitrary keys into `meta`.
- No-op when `request` is null (CLI / queue context).

### 2. `SensitiveFieldRule` — Monitor rule for sensitive field changes

```php
'sensitive_fields' => [
    'class' => \AuditStash\Monitor\Rule\SensitiveFieldRule::class,
    'tables' => ['Users', 'ApiKeys'],
    'fields' => ['password', 'role', 'two_factor_secret', 'api_token'],
    'severity' => 'high',
    'channels' => ['log', 'email'],
],
```

- Mirrors `MassDeleteRule`'s shape (`tables`, `severity`, `AbstractRule`) so it plugs into the existing `AuditMonitor` channel pipeline with zero infrastructure changes.
- Looks at `changed` for create/update events and `original` for delete events — password rotations and API-key revocations both fire.
- Empty `fields` config never matches (`empty` means "no sensitive fields configured", not "match everything").
- Tolerates string-encoded JSON payloads defensively.

### 3. `AuditAssertionsTrait` — testing helper for downstream apps

```php
use AuditStash\TestSuite\AuditAssertionsTrait;

class ArticlesControllerTest extends TestCase
{
    use AuditAssertionsTrait;

    protected array $fixtures = ['plugin.AuditStash.AuditLogs', 'app.Articles'];

    public function testArticleCreateIsAudited(): void
    {
        $this->post('/articles/add', ['title' => 'Hello']);

        $this->assertAuditLogged('Articles', 'create');
        $this->assertAuditFieldChanged('Articles', 'title', 'Hello');
        $this->assertAuditCount(1, 'Articles');
    }
}
```

Queries `audit_logs` directly, so assertions verify what was persisted — not just what an in-memory queue produced. Methods: `assertAuditLogged`, `assertAuditNotLogged`, `assertAuditCount`, `assertAuditFieldChanged`.

## Docs

- `docs/monitoring.md`: new `SensitiveFieldRule` section + example in the canonical config block
- `docs/usage.md`: EnvironmentMetadata `capture` documented under "Capturing forensic request fields"
- `README.md`: short "Asserting audit logs in your own tests" recipe under Testing

## Quality gates

- `vendor/bin/phpunit` — **336 tests / 992 assertions** (was 305 / 919)
- `vendor/bin/phpstan analyze` — clean. Added one `phpstan.neon` ignore for `trait.unused` under `src/TestSuite/*` since trait consumers live downstream.
- `vendor/bin/phpcs` — clean

## Out of scope (next-next)

`QueuedPersister` (async logging via cakephp-queue) — large enough to warrant its own PR with its own design surface (failure handling, transaction id pass-through, hash-chain-vs-async ordering). Held for later.
