### PR TITLE
Add lifecycle event hooks to AuditMonitor

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -284,6 +284,83 @@ class SlackChannel implements ChannelInterface
 }
 ```
 
+## Hooking Into the Monitor Lifecycle
+
+Channels are the happy-path delivery mechanism. For everything else — per-context suppression, alert mutation, custom incident store, paging integration, error routing — the monitor dispatches three CakePHP events around every alert. Listen with `EventManager::instance()->on(...)` exactly like any other CakePHP event.
+
+| Event | When | What you can do |
+|---|---|---|
+| `AuditStash.Monitor.beforeAlert` | After a rule matches and the `Alert` has been built, before any channel runs. Carries `rule`, `auditLog`, `alert`. | Call `$event->stopPropagation()` to suppress the alert (channels are skipped, `afterAlert` is not dispatched). Or replace the alert via `$event->setData('alert', $newAlert)` — the channels and `afterAlert` will see the replaced instance. |
+| `AuditStash.Monitor.afterAlert` | After every channel for the rule has been called. Carries `rule`, `auditLog`, `alert`, and `results` (a `[channelName => bool]` map of per-channel success). | React on success / failure — write to your own incident store, page on partial failures, emit telemetry. |
+| `AuditStash.Monitor.ruleException` | When a rule's `matches()` (or `createAlert()`) throws. Carries `rule`, `auditLog`, `exception`. | Forward the exception to Sentry / your error pipeline; today it is otherwise only logged. |
+
+### Suppress an alert under specific conditions
+
+```php
+EventManager::instance()->on(
+    'AuditStash.Monitor.beforeAlert',
+    function (EventInterface $event): void {
+        $alert = $event->getData('alert');
+        // Don't page during the migration window for tenant 42.
+        if ($alert->getAuditLog()->meta['tenant_id'] ?? null === 42) {
+            $event->stopPropagation();
+        }
+    },
+);
+```
+
+### Redact PII before delivery
+
+```php
+EventManager::instance()->on(
+    'AuditStash.Monitor.beforeAlert',
+    function (EventInterface $event): void {
+        $alert = $event->getData('alert');
+        $event->setData('alert', new Alert(
+            $alert->getRuleName(),
+            $alert->getSeverity(),
+            $alert->getMessage(),
+            $alert->getAuditLog(),
+            // Strip user_email from the alert context before any channel sees it.
+            array_diff_key($alert->getContext(), ['user_email' => 1]),
+        ));
+    },
+);
+```
+
+### Route to a non-channel target after delivery
+
+```php
+EventManager::instance()->on(
+    'AuditStash.Monitor.afterAlert',
+    function (EventInterface $event) use ($incidentStore): void {
+        if (in_array(false, $event->getData('results'), true)) {
+            // At least one channel failed. Persist the alert to a fallback table
+            // so on-call has something to triage even if Slack/email were down.
+            $incidentStore->writeFallback($event->getData('alert'));
+        }
+    },
+);
+```
+
+### Forward rule exceptions to your error reporter
+
+```php
+EventManager::instance()->on(
+    'AuditStash.Monitor.ruleException',
+    function (EventInterface $event) use ($sentry): void {
+        $sentry->captureException($event->getData('exception'), [
+            'extra' => [
+                'rule' => $event->getData('rule'),
+                'auditLog' => $event->getData('auditLog')->toArray(),
+            ],
+        ]);
+    },
+);
+```
+
+The events fire on the global `EventManager` (the same one CakePHP uses for everything else), so you can wire them up from `Application::bootstrap()`, a dedicated listener class, or anywhere else that runs at request boot time.
+
 ## Disabling Monitoring
 
 To disable monitoring entirely:

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -286,13 +286,17 @@ class SlackChannel implements ChannelInterface
 
 ## Hooking Into the Monitor Lifecycle
 
-Channels are the happy-path delivery mechanism. For everything else — per-context suppression, alert mutation, custom incident store, paging integration, error routing — the monitor dispatches three CakePHP events around every alert. Listen with `EventManager::instance()->on(...)` exactly like any other CakePHP event.
+Channels are the happy-path delivery mechanism. For everything else — per-context suppression, alert mutation, custom incident store, paging integration — the monitor dispatches two CakePHP events around every alert. Listen with `EventManager::instance()->on(...)` exactly like any other CakePHP event.
 
 | Event | When | What you can do |
 |---|---|---|
-| `AuditStash.Monitor.beforeAlert` | After a rule matches and the `Alert` has been built, before any channel runs. Carries `rule`, `auditLog`, `alert`. | Call `$event->stopPropagation()` to suppress the alert (channels are skipped, `afterAlert` is not dispatched). Or replace the alert via `$event->setData('alert', $newAlert)` — the channels and `afterAlert` will see the replaced instance. |
+| `AuditStash.Monitor.beforeAlert` | After a rule matches and the `Alert` has been built, before any channel runs. Carries `rule`, `auditLog`, `alert`. | Call `$event->stopPropagation()` to suppress the alert (channels are skipped, `afterAlert` is not dispatched). Or replace the alert via `$event->setData('alert', $newAlert)` — the channels and `afterAlert` will see the replaced instance. The `Alert` value object itself is immutable; mutation always goes through `setData`. |
 | `AuditStash.Monitor.afterAlert` | After every channel for the rule has been called. Carries `rule`, `auditLog`, `alert`, and `results` (a `[channelName => bool]` map of per-channel success). | React on success / failure — write to your own incident store, page on partial failures, emit telemetry. |
-| `AuditStash.Monitor.ruleException` | When a rule's `matches()` (or `createAlert()`) throws. Carries `rule`, `auditLog`, `exception`. | Forward the exception to Sentry / your error pipeline; today it is otherwise only logged. |
+
+> [!NOTE]
+> Listener exceptions are not caught by the monitor — they propagate to the caller. Silent listener failures hide app bugs, so a buggy listener crashes the request loudly rather than masquerading as a rule failure. Wrap your own listener body in `try/catch` if you want different behavior.
+
+For rule failures (anything thrown out of a rule's `matches()` or `createAlert()`, including `Error` subclasses like `TypeError`), the monitor catches the `Throwable`, logs it with the full exception in context (so Sentry / Monolog handlers attached via `Cake\Log\Log` capture the stack), and continues with the next rule. No separate event is emitted — the existing log pipeline handles the routing.
 
 ### Suppress an alert under specific conditions
 
@@ -345,19 +349,19 @@ EventManager::instance()->on(
 
 ### Forward rule exceptions to your error reporter
 
+Rule exceptions go through `Cake\Log\Log` with the full `Throwable` in the log context, so any handler that knows how to unpack `context.exception` (Monolog's `IntrospectionProcessor`, the `sentry/sentry` Cake bridge, etc.) gets the stack for free. Wire your error reporter as a normal log handler:
+
 ```php
-EventManager::instance()->on(
-    'AuditStash.Monitor.ruleException',
-    function (EventInterface $event) use ($sentry): void {
-        $sentry->captureException($event->getData('exception'), [
-            'extra' => [
-                'rule' => $event->getData('rule'),
-                'auditLog' => $event->getData('auditLog')->toArray(),
-            ],
-        ]);
-    },
-);
+'Log' => [
+    'sentry' => [
+        'className' => Sentry\Cake\Log\SentryLog::class,
+        'levels' => ['error', 'critical', 'alert', 'emergency'],
+        // ...
+    ],
+],
 ```
+
+Both rule-evaluation failures and channel-send failures already emit `error`-level log entries with `exception` in the context.
 
 The events fire on the global `EventManager` (the same one CakePHP uses for everything else), so you can wire them up from `Application::bootstrap()`, a dedicated listener class, or anywhere else that runs at request boot time.
 

--- a/src/Monitor/AuditMonitor.php
+++ b/src/Monitor/AuditMonitor.php
@@ -8,6 +8,7 @@ use AuditStash\Model\Entity\AuditLog;
 use AuditStash\Monitor\Channel\ChannelInterface;
 use AuditStash\Monitor\Rule\AbstractRule;
 use Cake\Core\Configure;
+use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventInterface;
 use Cake\Event\EventListenerInterface;
 use Exception;
@@ -18,15 +19,18 @@ use Psr\Log\LoggerAwareTrait;
  */
 class AuditMonitor implements EventListenerInterface
 {
+    use EventDispatcherTrait;
     use LoggerAwareTrait;
 
     /**
-     * @var array<\AuditStash\Monitor\Rule\AbstractRule>
+     * @var array<string, \AuditStash\Monitor\Rule\AbstractRule>
      */
     protected array $rules = [];
 
     /**
-     * @var array<string, array<\AuditStash\Monitor\Channel\ChannelInterface>>
+     * Channel instances grouped by rule name and keyed by channel name.
+     *
+     * @var array<string, array<string, \AuditStash\Monitor\Channel\ChannelInterface>>
      */
     protected array $channels = [];
 
@@ -70,7 +74,25 @@ class AuditMonitor implements EventListenerInterface
     }
 
     /**
-     * Check all rules against an audit log and send alerts.
+     * Check all rules against an audit log and dispatch matching alerts
+     * through the lifecycle event hooks.
+     *
+     * Lifecycle for each matching rule:
+     *
+     * 1. `AuditStash.Monitor.beforeAlert` is dispatched with `rule`,
+     *    `auditLog`, and `alert`. Listeners can call `stopPropagation()`
+     *    on the event to suppress the alert — channels are skipped and
+     *    `afterAlert` is not dispatched. Listeners can also mutate the
+     *    `Alert` instance in-place (severity, message, context) before
+     *    delivery.
+     * 2. Channels run.
+     * 3. `AuditStash.Monitor.afterAlert` is dispatched with `rule`,
+     *    `auditLog`, `alert`, and `results` (a `[channelName => bool]`
+     *    map of per-channel success).
+     *
+     * Rule exceptions are still caught and logged, but now also
+     * dispatched as `AuditStash.Monitor.ruleException` so user code can
+     * route them somewhere actionable.
      *
      * @param \AuditStash\Model\Entity\AuditLog $auditLog The audit log to check
      *
@@ -80,14 +102,44 @@ class AuditMonitor implements EventListenerInterface
     {
         foreach ($this->rules as $ruleName => $rule) {
             try {
-                if ($rule->matches($auditLog)) {
-                    $alert = $rule->createAlert($auditLog);
-                    $this->sendAlert($ruleName, $alert);
+                if (!$rule->matches($auditLog)) {
+                    continue;
                 }
+
+                $alert = $rule->createAlert($auditLog);
+
+                $beforeEvent = $this->dispatchEvent('AuditStash.Monitor.beforeAlert', [
+                    'rule' => $ruleName,
+                    'auditLog' => $auditLog,
+                    'alert' => $alert,
+                ]);
+                if ($beforeEvent->isStopped()) {
+                    continue;
+                }
+                // Listeners can swap the alert via $event->setData('alert', ...);
+                // pick that up so mutated alerts reach the channels.
+                $alertFromEvent = $beforeEvent->getData('alert');
+                if ($alertFromEvent instanceof Alert) {
+                    $alert = $alertFromEvent;
+                }
+
+                $results = $this->sendAlert($ruleName, $alert);
+
+                $this->dispatchEvent('AuditStash.Monitor.afterAlert', [
+                    'rule' => $ruleName,
+                    'auditLog' => $auditLog,
+                    'alert' => $alert,
+                    'results' => $results,
+                ]);
             } catch (Exception $e) {
                 $this->logger?->error('AuditMonitor: Rule check failed', [
                     'rule' => $ruleName,
                     'error' => $e->getMessage(),
+                ]);
+                $this->dispatchEvent('AuditStash.Monitor.ruleException', [
+                    'rule' => $ruleName,
+                    'auditLog' => $auditLog,
+                    'exception' => $e,
                 ]);
             }
         }
@@ -99,16 +151,17 @@ class AuditMonitor implements EventListenerInterface
      * @param string $ruleName The rule name
      * @param \AuditStash\Monitor\Alert $alert The alert to send
      *
-     * @return void
+     * @return array<string, bool> Per-channel success map keyed by channel name
      */
-    protected function sendAlert(string $ruleName, Alert $alert): void
+    protected function sendAlert(string $ruleName, Alert $alert): array
     {
-        $channels = $this->channels[$ruleName] ?? [];
+        $results = [];
 
-        foreach ($channels as $channel) {
+        foreach ($this->channels[$ruleName] ?? [] as $channelName => $channel) {
             try {
-                $channel->send($alert);
+                $results[$channelName] = (bool)$channel->send($alert);
             } catch (Exception $e) {
+                $results[$channelName] = false;
                 $this->logger?->error('AuditMonitor: Channel send failed', [
                     'rule' => $ruleName,
                     'channel' => get_class($channel),
@@ -116,6 +169,8 @@ class AuditMonitor implements EventListenerInterface
                 ]);
             }
         }
+
+        return $results;
     }
 
     /**
@@ -142,7 +197,7 @@ class AuditMonitor implements EventListenerInterface
                 $this->channels[$ruleName] = [];
                 foreach ($channelNames as $channelName) {
                     if (isset($channelInstances[$channelName])) {
-                        $this->channels[$ruleName][] = $channelInstances[$channelName];
+                        $this->channels[$ruleName][$channelName] = $channelInstances[$channelName];
                     }
                 }
             }

--- a/src/Monitor/AuditMonitor.php
+++ b/src/Monitor/AuditMonitor.php
@@ -13,6 +13,7 @@ use Cake\Event\EventInterface;
 use Cake\Event\EventListenerInterface;
 use Exception;
 use Psr\Log\LoggerAwareTrait;
+use Throwable;
 
 /**
  * Monitors audit events and triggers alerts based on configured rules.
@@ -81,18 +82,22 @@ class AuditMonitor implements EventListenerInterface
      *
      * 1. `AuditStash.Monitor.beforeAlert` is dispatched with `rule`,
      *    `auditLog`, and `alert`. Listeners can call `stopPropagation()`
-     *    on the event to suppress the alert — channels are skipped and
-     *    `afterAlert` is not dispatched. Listeners can also mutate the
-     *    `Alert` instance in-place (severity, message, context) before
-     *    delivery.
+     *    on the event to suppress the alert (channels are skipped and
+     *    `afterAlert` is not dispatched), or replace the alert via
+     *    `$event->setData('alert', $newAlert)` — the channels and
+     *    `afterAlert` will see the replacement. The `Alert` value object
+     *    itself is immutable; mutation always goes through `setData`.
      * 2. Channels run.
      * 3. `AuditStash.Monitor.afterAlert` is dispatched with `rule`,
      *    `auditLog`, `alert`, and `results` (a `[channelName => bool]`
      *    map of per-channel success).
      *
-     * Rule exceptions are still caught and logged, but now also
-     * dispatched as `AuditStash.Monitor.ruleException` so user code can
-     * route them somewhere actionable.
+     * Rule exceptions (anything thrown out of `matches()` or
+     * `createAlert()`, including `Error` subclasses like `TypeError`) are
+     * caught and logged with the full `Throwable` in the log context so
+     * Sentry / Monolog handlers can capture the stack. Listener
+     * exceptions are NOT caught — they propagate to the caller, because
+     * silent listener failures hide app bugs.
      *
      * @param \AuditStash\Model\Entity\AuditLog $auditLog The audit log to check
      *
@@ -105,55 +110,71 @@ class AuditMonitor implements EventListenerInterface
                 if (!$rule->matches($auditLog)) {
                     continue;
                 }
-
                 $alert = $rule->createAlert($auditLog);
-
-                $beforeEvent = $this->dispatchEvent('AuditStash.Monitor.beforeAlert', [
-                    'rule' => $ruleName,
-                    'auditLog' => $auditLog,
-                    'alert' => $alert,
-                ]);
-                if ($beforeEvent->isStopped()) {
-                    continue;
-                }
-                // Listeners can swap the alert via $event->setData('alert', ...);
-                // pick that up so mutated alerts reach the channels.
-                $alertFromEvent = $beforeEvent->getData('alert');
-                if ($alertFromEvent instanceof Alert) {
-                    $alert = $alertFromEvent;
-                }
-
-                $results = $this->sendAlert($ruleName, $alert);
-
-                $this->dispatchEvent('AuditStash.Monitor.afterAlert', [
-                    'rule' => $ruleName,
-                    'auditLog' => $auditLog,
-                    'alert' => $alert,
-                    'results' => $results,
-                ]);
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 $this->logger?->error('AuditMonitor: Rule check failed', [
                     'rule' => $ruleName,
-                    'error' => $e->getMessage(),
-                ]);
-                $this->dispatchEvent('AuditStash.Monitor.ruleException', [
-                    'rule' => $ruleName,
-                    'auditLog' => $auditLog,
                     'exception' => $e,
                 ]);
+
+                continue;
             }
+
+            $beforeEvent = $this->dispatchEvent('AuditStash.Monitor.beforeAlert', [
+                'rule' => $ruleName,
+                'auditLog' => $auditLog,
+                'alert' => $alert,
+            ]);
+            if ($beforeEvent->isStopped()) {
+                continue;
+            }
+            // Listeners can swap the alert via $event->setData('alert', ...);
+            // pick that up so the replacement reaches the channels.
+            $alertFromEvent = $beforeEvent->getData('alert');
+            if ($alertFromEvent instanceof Alert) {
+                $alert = $alertFromEvent;
+            }
+
+            $results = $this->dispatchToChannels($ruleName, $alert);
+
+            $this->dispatchEvent('AuditStash.Monitor.afterAlert', [
+                'rule' => $ruleName,
+                'auditLog' => $auditLog,
+                'alert' => $alert,
+                'results' => $results,
+            ]);
         }
     }
 
     /**
-     * Send alert through configured channels for a rule.
+     * Send an alert through every channel registered for this rule, kept
+     * as the historical no-result entry point so downstream subclasses
+     * that override the protected method continue to load and run.
+     *
+     * Most callers should reach for {@see dispatchToChannels()} instead,
+     * which returns the per-channel success map used by the
+     * `afterAlert` event.
+     *
+     * @param string $ruleName The rule name
+     * @param \AuditStash\Monitor\Alert $alert The alert to send
+     *
+     * @return void
+     */
+    protected function sendAlert(string $ruleName, Alert $alert): void
+    {
+        $this->dispatchToChannels($ruleName, $alert);
+    }
+
+    /**
+     * Send alert through configured channels for a rule and collect a
+     * per-channel success map.
      *
      * @param string $ruleName The rule name
      * @param \AuditStash\Monitor\Alert $alert The alert to send
      *
      * @return array<string, bool> Per-channel success map keyed by channel name
      */
-    protected function sendAlert(string $ruleName, Alert $alert): array
+    protected function dispatchToChannels(string $ruleName, Alert $alert): array
     {
         $results = [];
 
@@ -165,7 +186,7 @@ class AuditMonitor implements EventListenerInterface
                 $this->logger?->error('AuditMonitor: Channel send failed', [
                     'rule' => $ruleName,
                     'channel' => get_class($channel),
-                    'error' => $e->getMessage(),
+                    'exception' => $e,
                 ]);
             }
         }

--- a/tests/TestCase/Monitor/AuditMonitorTest.php
+++ b/tests/TestCase/Monitor/AuditMonitorTest.php
@@ -13,12 +13,15 @@ use Cake\Event\Event;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use TestApp\Monitor\Channel\ExplodingChannel;
 use TestApp\Monitor\Channel\RecordingChannel;
 use TestApp\Monitor\Rule\AlwaysMatchRule;
 use TestApp\Monitor\Rule\ExplodingRule;
 use TestApp\Monitor\Rule\NeverMatchRule;
+use TestApp\Monitor\Rule\TypeErrorRule;
 
 class AuditMonitorTest extends TestCase
 {
@@ -144,9 +147,26 @@ class AuditMonitorTest extends TestCase
         $this->assertSame(['mutated' => true], $delivered->getContext());
     }
 
-    public function testRuleExceptionDispatchesRuleExceptionEventAndDoesNotBreakOtherRules(): void
+    public function testRuleExceptionIsLoggedAndDoesNotBreakOtherRules(): void
     {
-        $caught = null;
+        $captured = [];
+        $logger = new class ($captured) extends AbstractLogger {
+            public function __construct(private array &$captured)
+            {
+            }
+
+            /**
+             * @param mixed $level
+             * @param \Stringable|string $message
+             * @param array<string, mixed> $context
+             *
+             * @return void
+             */
+            public function log($level, $message, array $context = []): void
+            {
+                $this->captured[] = ['level' => $level, 'message' => (string)$message, 'context' => $context];
+            }
+        };
 
         $this->configureMonitor([
             'rules' => [
@@ -156,25 +176,77 @@ class AuditMonitorTest extends TestCase
             'channels' => [
                 'ok' => ['class' => RecordingChannel::class, 'returns' => true],
             ],
-        ]);
-
-        EventManager::instance()->on(
-            'AuditStash.Monitor.ruleException',
-            function (EventInterface $event) use (&$caught): void {
-                $caught = $event->getData('exception');
-            },
-        );
+        ], $logger);
 
         $this->dispatchAuditLog();
 
-        $this->assertInstanceOf(RuntimeException::class, $caught);
-        $this->assertSame('rule blew up', $caught->getMessage());
+        // Good rule still ran after the broken one failed.
         $this->assertCount(1, RecordingChannel::$delivered);
+
+        // The broken rule's failure was logged with the full Throwable in
+        // context (so Sentry / Monolog handlers get the stack).
+        $brokenLog = null;
+        foreach ($captured as $entry) {
+            if (str_contains($entry['message'], 'Rule check failed')) {
+                $brokenLog = $entry;
+
+                break;
+            }
+        }
+        $this->assertNotNull($brokenLog);
+        $this->assertSame('broken', $brokenLog['context']['rule']);
+        $this->assertInstanceOf(RuntimeException::class, $brokenLog['context']['exception']);
+        $this->assertSame('rule blew up', $brokenLog['context']['exception']->getMessage());
+    }
+
+    public function testRuleErrorIsCaughtAsThrowable(): void
+    {
+        // matches() throwing TypeError must not escape the monitor.
+        $this->configureMonitor([
+            'rules' => [
+                'type_error' => ['class' => TypeErrorRule::class],
+                'good' => ['class' => AlwaysMatchRule::class, 'channels' => ['ok']],
+            ],
+            'channels' => [
+                'ok' => ['class' => RecordingChannel::class, 'returns' => true],
+            ],
+        ]);
+
+        $this->dispatchAuditLog();
+
+        // No exception escaped; the good rule still delivered.
+        $this->assertCount(1, RecordingChannel::$delivered);
+    }
+
+    public function testListenerExceptionPropagatesAndIsNotMisclassifiedAsRuleFailure(): void
+    {
+        $this->configureMonitor([
+            'rules' => [
+                'test' => ['class' => AlwaysMatchRule::class, 'channels' => ['ok']],
+            ],
+            'channels' => [
+                'ok' => ['class' => RecordingChannel::class, 'returns' => true],
+            ],
+        ]);
+
+        EventManager::instance()->on(
+            'AuditStash.Monitor.beforeAlert',
+            function (): void {
+                throw new RuntimeException('listener bug');
+            },
+        );
+
+        // Listener bug propagates rather than being silently swallowed —
+        // hidden listener failures are worse than loud ones.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('listener bug');
+
+        $this->dispatchAuditLog();
     }
 
     public function testNonMatchingRuleFiresNoEvents(): void
     {
-        $beforeFired = $afterFired = $exceptionFired = false;
+        $beforeFired = $afterFired = false;
 
         $this->configureMonitor([
             'rules' => ['never' => ['class' => NeverMatchRule::class]],
@@ -187,15 +259,11 @@ class AuditMonitorTest extends TestCase
         EventManager::instance()->on('AuditStash.Monitor.afterAlert', function () use (&$afterFired): void {
             $afterFired = true;
         });
-        EventManager::instance()->on('AuditStash.Monitor.ruleException', function () use (&$exceptionFired): void {
-            $exceptionFired = true;
-        });
 
         $this->dispatchAuditLog();
 
         $this->assertFalse($beforeFired);
         $this->assertFalse($afterFired);
-        $this->assertFalse($exceptionFired);
     }
 
     public function testChannelExceptionMarksItFailedButContinuesOtherChannels(): void
@@ -236,13 +304,17 @@ class AuditMonitorTest extends TestCase
 
     /**
      * @param array{rules?: array<string, mixed>, channels?: array<string, mixed>} $monitorConfig
+     * @param \Psr\Log\LoggerInterface|null $logger Optional logger for capturing rule/channel-failure log calls
      */
-    private function configureMonitor(array $monitorConfig): AuditMonitor
+    private function configureMonitor(array $monitorConfig, ?LoggerInterface $logger = null): AuditMonitor
     {
         Configure::write('AuditStash.monitor.rules', $monitorConfig['rules'] ?? []);
         Configure::write('AuditStash.monitor.channels', $monitorConfig['channels'] ?? []);
 
         $monitor = new AuditMonitor();
+        if ($logger !== null) {
+            $monitor->setLogger($logger);
+        }
         EventManager::instance()->on($monitor);
 
         return $monitor;

--- a/tests/TestCase/Monitor/AuditMonitorTest.php
+++ b/tests/TestCase/Monitor/AuditMonitorTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\Test\TestCase\Monitor;
+
+use AuditStash\AuditLogType;
+use AuditStash\Model\Entity\AuditLog;
+use AuditStash\Monitor\Alert;
+use AuditStash\Monitor\AuditMonitor;
+use Cake\Core\Configure;
+use Cake\Event\Event;
+use Cake\Event\EventInterface;
+use Cake\Event\EventManager;
+use Cake\TestSuite\TestCase;
+use RuntimeException;
+use TestApp\Monitor\Channel\ExplodingChannel;
+use TestApp\Monitor\Channel\RecordingChannel;
+use TestApp\Monitor\Rule\AlwaysMatchRule;
+use TestApp\Monitor\Rule\ExplodingRule;
+use TestApp\Monitor\Rule\NeverMatchRule;
+
+class AuditMonitorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Configure::write('AuditStash.monitor.enabled', true);
+        RecordingChannel::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        Configure::delete('AuditStash.monitor');
+        EventManager::instance(new EventManager());
+        RecordingChannel::reset();
+        parent::tearDown();
+    }
+
+    public function testHappyPathFiresBothLifecycleEventsAndChannel(): void
+    {
+        $beforeFired = $afterFired = false;
+        $afterResults = null;
+
+        $this->configureMonitor([
+            'rules' => [
+                'test' => ['class' => AlwaysMatchRule::class, 'channels' => ['ok', 'fail']],
+            ],
+            'channels' => [
+                'ok' => ['class' => RecordingChannel::class, 'returns' => true],
+                'fail' => ['class' => RecordingChannel::class, 'returns' => false],
+            ],
+        ]);
+
+        EventManager::instance()->on(
+            'AuditStash.Monitor.beforeAlert',
+            function (EventInterface $event) use (&$beforeFired): void {
+                $beforeFired = true;
+                $this->assertSame('test', $event->getData('rule'));
+                $this->assertInstanceOf(Alert::class, $event->getData('alert'));
+            },
+        );
+        EventManager::instance()->on(
+            'AuditStash.Monitor.afterAlert',
+            function (EventInterface $event) use (&$afterFired, &$afterResults): void {
+                $afterFired = true;
+                $afterResults = $event->getData('results');
+            },
+        );
+
+        $this->dispatchAuditLog();
+
+        $this->assertTrue($beforeFired);
+        $this->assertTrue($afterFired);
+        $this->assertSame(['ok' => true, 'fail' => false], $afterResults);
+        $this->assertCount(2, RecordingChannel::$delivered);
+    }
+
+    public function testBeforeAlertStopPropagationSuppressesChannelsAndAfterEvent(): void
+    {
+        $afterFired = false;
+
+        $this->configureMonitor([
+            'rules' => [
+                'test' => ['class' => AlwaysMatchRule::class, 'channels' => ['ok']],
+            ],
+            'channels' => [
+                'ok' => ['class' => RecordingChannel::class, 'returns' => true],
+            ],
+        ]);
+
+        EventManager::instance()->on(
+            'AuditStash.Monitor.beforeAlert',
+            function (EventInterface $event): void {
+                $event->stopPropagation();
+            },
+        );
+        EventManager::instance()->on(
+            'AuditStash.Monitor.afterAlert',
+            function () use (&$afterFired): void {
+                $afterFired = true;
+            },
+        );
+
+        $this->dispatchAuditLog();
+
+        $this->assertSame([], RecordingChannel::$delivered);
+        $this->assertFalse($afterFired);
+    }
+
+    public function testBeforeAlertCanReplaceTheAlertViaSetData(): void
+    {
+        $this->configureMonitor([
+            'rules' => [
+                'test' => ['class' => AlwaysMatchRule::class, 'channels' => ['capture']],
+            ],
+            'channels' => [
+                'capture' => ['class' => RecordingChannel::class, 'returns' => true],
+            ],
+        ]);
+
+        EventManager::instance()->on(
+            'AuditStash.Monitor.beforeAlert',
+            function (EventInterface $event): void {
+                /** @var \AuditStash\Monitor\Alert $alert */
+                $alert = $event->getData('alert');
+                $event->setData('alert', new Alert(
+                    'MutatedRule',
+                    'critical',
+                    'redacted',
+                    $alert->getAuditLog(),
+                    ['mutated' => true],
+                ));
+            },
+        );
+
+        $this->dispatchAuditLog();
+
+        $this->assertCount(1, RecordingChannel::$delivered);
+        $delivered = RecordingChannel::$delivered[0];
+        $this->assertSame('MutatedRule', $delivered->getRuleName());
+        $this->assertSame('critical', $delivered->getSeverity());
+        $this->assertSame('redacted', $delivered->getMessage());
+        $this->assertSame(['mutated' => true], $delivered->getContext());
+    }
+
+    public function testRuleExceptionDispatchesRuleExceptionEventAndDoesNotBreakOtherRules(): void
+    {
+        $caught = null;
+
+        $this->configureMonitor([
+            'rules' => [
+                'broken' => ['class' => ExplodingRule::class],
+                'good' => ['class' => AlwaysMatchRule::class, 'channels' => ['ok']],
+            ],
+            'channels' => [
+                'ok' => ['class' => RecordingChannel::class, 'returns' => true],
+            ],
+        ]);
+
+        EventManager::instance()->on(
+            'AuditStash.Monitor.ruleException',
+            function (EventInterface $event) use (&$caught): void {
+                $caught = $event->getData('exception');
+            },
+        );
+
+        $this->dispatchAuditLog();
+
+        $this->assertInstanceOf(RuntimeException::class, $caught);
+        $this->assertSame('rule blew up', $caught->getMessage());
+        $this->assertCount(1, RecordingChannel::$delivered);
+    }
+
+    public function testNonMatchingRuleFiresNoEvents(): void
+    {
+        $beforeFired = $afterFired = $exceptionFired = false;
+
+        $this->configureMonitor([
+            'rules' => ['never' => ['class' => NeverMatchRule::class]],
+            'channels' => [],
+        ]);
+
+        EventManager::instance()->on('AuditStash.Monitor.beforeAlert', function () use (&$beforeFired): void {
+            $beforeFired = true;
+        });
+        EventManager::instance()->on('AuditStash.Monitor.afterAlert', function () use (&$afterFired): void {
+            $afterFired = true;
+        });
+        EventManager::instance()->on('AuditStash.Monitor.ruleException', function () use (&$exceptionFired): void {
+            $exceptionFired = true;
+        });
+
+        $this->dispatchAuditLog();
+
+        $this->assertFalse($beforeFired);
+        $this->assertFalse($afterFired);
+        $this->assertFalse($exceptionFired);
+    }
+
+    public function testChannelExceptionMarksItFailedButContinuesOtherChannels(): void
+    {
+        $afterResults = null;
+
+        $this->configureMonitor([
+            'rules' => [
+                'test' => ['class' => AlwaysMatchRule::class, 'channels' => ['boom', 'ok']],
+            ],
+            'channels' => [
+                'boom' => ['class' => ExplodingChannel::class],
+                'ok' => ['class' => RecordingChannel::class, 'returns' => true],
+            ],
+        ]);
+
+        EventManager::instance()->on(
+            'AuditStash.Monitor.afterAlert',
+            function (EventInterface $event) use (&$afterResults): void {
+                $afterResults = $event->getData('results');
+            },
+        );
+
+        $this->dispatchAuditLog();
+
+        $this->assertSame(['boom' => false, 'ok' => true], $afterResults);
+        $this->assertCount(1, RecordingChannel::$delivered);
+    }
+
+    public function testMonitorIsInertWhenDisabled(): void
+    {
+        Configure::write('AuditStash.monitor.enabled', false);
+
+        $monitor = new AuditMonitor();
+
+        $this->assertSame([], $monitor->implementedEvents());
+    }
+
+    /**
+     * @param array{rules?: array<string, mixed>, channels?: array<string, mixed>} $monitorConfig
+     */
+    private function configureMonitor(array $monitorConfig): AuditMonitor
+    {
+        Configure::write('AuditStash.monitor.rules', $monitorConfig['rules'] ?? []);
+        Configure::write('AuditStash.monitor.channels', $monitorConfig['channels'] ?? []);
+
+        $monitor = new AuditMonitor();
+        EventManager::instance()->on($monitor);
+
+        return $monitor;
+    }
+
+    private function dispatchAuditLog(): void
+    {
+        $auditLog = new AuditLog([
+            'id' => 1,
+            'type' => AuditLogType::Update->value,
+            'source' => 'Articles',
+            'primary_key' => 7,
+        ]);
+
+        EventManager::instance()->dispatch(
+            new Event('AuditStash.afterLog', null, ['auditLog' => $auditLog]),
+        );
+    }
+}

--- a/tests/test_app/src/Monitor/Channel/ExplodingChannel.php
+++ b/tests/test_app/src/Monitor/Channel/ExplodingChannel.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp\Monitor\Channel;
+
+use AuditStash\Monitor\Alert;
+use AuditStash\Monitor\Channel\ChannelInterface;
+use RuntimeException;
+
+/**
+ * Channel test double whose `send()` throws. Used to verify that
+ * AuditMonitor catches per-channel exceptions, marks the channel as
+ * failed in the afterAlert results map, and continues delivering to the
+ * remaining channels.
+ */
+class ExplodingChannel implements ChannelInterface
+{
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(array $config = [])
+    {
+    }
+
+    public function send(Alert $alert): bool
+    {
+        throw new RuntimeException('channel blew up');
+    }
+}

--- a/tests/test_app/src/Monitor/Channel/RecordingChannel.php
+++ b/tests/test_app/src/Monitor/Channel/RecordingChannel.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp\Monitor\Channel;
+
+use AuditStash\Monitor\Alert;
+use AuditStash\Monitor\Channel\ChannelInterface;
+
+/**
+ * Channel test double that records every alert it receives in a static
+ * accumulator. The `returns` config key controls whether `send()` reports
+ * success — used by AuditMonitor lifecycle tests to exercise both
+ * outcomes through the channel pipeline.
+ */
+class RecordingChannel implements ChannelInterface
+{
+    /**
+     * @var array<int, \AuditStash\Monitor\Alert>
+     */
+    public static array $delivered = [];
+
+    private bool $returns;
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(array $config = [])
+    {
+        $this->returns = (bool)($config['returns'] ?? true);
+    }
+
+    public function send(Alert $alert): bool
+    {
+        self::$delivered[] = $alert;
+
+        return $this->returns;
+    }
+
+    public static function reset(): void
+    {
+        self::$delivered = [];
+    }
+}

--- a/tests/test_app/src/Monitor/Rule/AlwaysMatchRule.php
+++ b/tests/test_app/src/Monitor/Rule/AlwaysMatchRule.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp\Monitor\Rule;
+
+use AuditStash\Model\Entity\AuditLog;
+use AuditStash\Monitor\Rule\AbstractRule;
+
+/**
+ * Rule that always matches. Used by AuditMonitor lifecycle tests where
+ * the rule body is not under test.
+ */
+class AlwaysMatchRule extends AbstractRule
+{
+    public function matches(AuditLog $auditLog): bool
+    {
+        return true;
+    }
+
+    public function getSeverity(): string
+    {
+        return 'high';
+    }
+
+    public function getMessage(AuditLog $auditLog): string
+    {
+        return 'matched';
+    }
+}

--- a/tests/test_app/src/Monitor/Rule/ExplodingRule.php
+++ b/tests/test_app/src/Monitor/Rule/ExplodingRule.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp\Monitor\Rule;
+
+use AuditStash\Model\Entity\AuditLog;
+use AuditStash\Monitor\Rule\AbstractRule;
+use RuntimeException;
+
+/**
+ * Rule whose `matches()` throws. Used by AuditMonitor lifecycle tests
+ * to verify the `AuditStash.Monitor.ruleException` event fires and that
+ * the exception in one rule does not break later rules in the chain.
+ */
+class ExplodingRule extends AbstractRule
+{
+    public function matches(AuditLog $auditLog): bool
+    {
+        throw new RuntimeException('rule blew up');
+    }
+
+    public function getSeverity(): string
+    {
+        return 'low';
+    }
+
+    public function getMessage(AuditLog $auditLog): string
+    {
+        return '';
+    }
+}

--- a/tests/test_app/src/Monitor/Rule/NeverMatchRule.php
+++ b/tests/test_app/src/Monitor/Rule/NeverMatchRule.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp\Monitor\Rule;
+
+use AuditStash\Model\Entity\AuditLog;
+use AuditStash\Monitor\Rule\AbstractRule;
+
+/**
+ * Rule that never matches. Used by AuditMonitor lifecycle tests to
+ * verify that no events fire when no rule matches.
+ */
+class NeverMatchRule extends AbstractRule
+{
+    public function matches(AuditLog $auditLog): bool
+    {
+        return false;
+    }
+
+    public function getSeverity(): string
+    {
+        return 'low';
+    }
+
+    public function getMessage(AuditLog $auditLog): string
+    {
+        return '';
+    }
+}

--- a/tests/test_app/src/Monitor/Rule/TypeErrorRule.php
+++ b/tests/test_app/src/Monitor/Rule/TypeErrorRule.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp\Monitor\Rule;
+
+use AuditStash\Model\Entity\AuditLog;
+use AuditStash\Monitor\Rule\AbstractRule;
+use TypeError;
+
+/**
+ * Rule whose `matches()` raises a `TypeError`. Used to verify that the
+ * monitor catches the full `Throwable` hierarchy (Errors as well as
+ * Exceptions), so a typo / null-deref bug in one rule does not abort
+ * the rest of the rule chain.
+ */
+class TypeErrorRule extends AbstractRule
+{
+    public function matches(AuditLog $auditLog): bool
+    {
+        throw new TypeError('null dereference');
+    }
+
+    public function getSeverity(): string
+    {
+        return 'low';
+    }
+
+    public function getMessage(AuditLog $auditLog): string
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
Adds CakePHP event hooks around `AuditMonitor`'s rule-check and channel-dispatch flow so app code can react to alerts however it wants — without writing a Channel subclass per use case.

## What's in the PR

Two new events on the global `EventManager`:

| Event | When | Levers |
|---|---|---|
| `AuditStash.Monitor.beforeAlert` | After a rule matches and the `Alert` is built, before any channel runs. | `stopPropagation()` to suppress (channels skipped, `afterAlert` not dispatched). `setData('alert', $new)` to replace the alert before delivery — channels see the replacement. The `Alert` value object is immutable; replacement always goes through `setData`. |
| `AuditStash.Monitor.afterAlert` | After every channel for the rule has been called. | Carries `results` — a `[channelName => bool]` map, so listeners can react on partial channel failures (write to fallback incident store, page on-call, etc.). |

For rule failures (anything thrown out of `matches()` or `createAlert()`, including `Error` subclasses like `TypeError`), the monitor catches the `Throwable`, logs it with `exception => $e` in the log context (so PSR-3 handlers like Monolog's `IntrospectionProcessor` or the `sentry/sentry` Cake bridge unpack the full stack), and continues with the next rule. **No separate `ruleException` event** — the existing log pipeline handles the routing, and an extra event was redundant API surface.

## Why

Channels are the happy-path delivery mechanism — but they're a closed set. Anything beyond the bundled platforms (Mattermost, PagerDuty, custom incident store, per-tenant suppression, alert mutation) currently requires either a Channel subclass per use case or no clean hook at all (channels can't observe each other's results, can't cancel delivery).

This PR is the open extensibility layer that pairs with the bundled channels: channels for the 80% drop-in case, events for the 20% that wants control.

## Implementation notes

- `AuditMonitor` now uses `Cake\Event\EventDispatcherTrait` for dispatch.
- **Rule try/catch wraps only `matches()` / `createAlert()`** — lifecycle event dispatch lives outside the catch, so listener exceptions propagate to the caller as the application bug they are. Silent listener failures hide app bugs.
- **Catch widened from `Exception` to `Throwable`** so `TypeError` / `ArgumentCountError` from a buggy rule no longer abort the rule chain.
- **Log context now passes the full `Throwable`** (`exception => $e`) instead of just the message string, so PSR-3 handlers can reconstruct the stack.
- After `beforeAlert` dispatches, the post-dispatch alert is read back from `$event->getData('alert')` so listeners can swap it.
- Channel storage was restructured from indexed array to `channelName`-keyed array per rule so the `afterAlert` results map keys match the names from the user's `monitor.channels` config.
- Channel exceptions now record `false` in the results array, so `afterAlert` listeners can react to partial channel failures.

## BC

- `AuditMonitor::sendAlert(string, Alert): void` is unchanged. A new method `dispatchToChannels(string, Alert): array<string, bool>` carries the result-returning path; `sendAlert()` is a thin `void`-returning facade. Subclasses overriding the historical `void` method continue to load and run.
- No new config keys; this is pure event-bus exposure.

## Tests

9 new tests in `AuditMonitorTest`:
- happy path: both lifecycle events fire, channels deliver, results map populated
- `beforeAlert` `stopPropagation()` suppresses channels and `afterAlert`
- `beforeAlert` can replace the alert via `setData('alert', ...)`; channels see the replacement
- rule exception is logged with full `Throwable` in context, doesn't break later rules
- rule `TypeError` is caught as `Throwable`, doesn't escape the monitor
- listener exception propagates (not misclassified as a rule failure)
- non-matching rule fires no events
- channel exception records `false` in results, other channels still deliver
- monitor is inert when `enabled = false`

Test fixtures live under `tests/test_app/src/Monitor/` per PSR-4.

## Docs

`docs/monitoring.md`: new "Hooking Into the Monitor Lifecycle" section with a per-event table, a note about listener exceptions propagating, and three copy-paste recipes (per-context suppression, PII redaction via replacement, fallback delivery on channel failure). Plus a short paragraph showing how to wire Sentry as a `Cake\Log\Log` handler — that's the recommended path for capturing rule/channel-failure stacks.

## Quality gates

- `vendor/bin/phpunit` — **345 tests / 1018 assertions** (was 336 / 992)
- `vendor/bin/phpstan analyze` — clean
- `vendor/bin/phpcs` — clean

## Related

Pairs with #56 (native Slack / Discord channels). The two PRs are independent and either order works for review/merge.