### PR TITLE
Move export to its own page, stream the output, cap result-set size

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -172,6 +172,30 @@ return [
         ],
 
         /**
+         * Admin-UI export tuning.
+         *
+         * The /admin/audit-stash/audit-logs/export page (and the inline
+         * "Export CSV" quick button on the index) stream CSV / JSON / NDJSON
+         * downloads with a hard row cap and a default date-range floor.
+         *
+         * - `hardCap`: maximum number of rows the streaming export will
+         *   produce. Pre-flighted with a count() before any download starts;
+         *   exceeding sets returns 400 with a "narrow your filters" message
+         *   rather than silently truncating.
+         * - `defaultDays`: when neither `date_from` nor `date_to` is
+         *   supplied, the export defaults the lower bound to "now minus N
+         *   days" so an unbounded export does not get slower with every
+         *   passing month. An explicit `date_from` overrides this.
+         * - `batchSize`: rows iterated and flushed per batch during the
+         *   stream. Memory is roughly O(batchSize × row size).
+         */
+        'export' => [
+            'hardCap' => 100000,
+            'defaultDays' => 30,
+            'batchSize' => 1000,
+        ],
+
+        /**
          * Real-time monitoring & alerting.
          *
          * The plugin ships a passive `AuditMonitor` that listens to persisted

--- a/docs/viewer.md
+++ b/docs/viewer.md
@@ -10,7 +10,8 @@ Default routes are available at:
 - **Browse logs**: `/admin/audit-logs`
 - **View single log**: `/admin/audit-logs/view/{id}`
 - **Record timeline**: `/admin/audit-logs/timeline/{table}/{recordId}`
-- **Export**: `/admin/audit-logs/export.csv` or `/admin/audit-logs/export.json`
+- **Export form**: `/admin/audit-logs/export` — dedicated page with format picker (CSV / JSON / NDJSON), row-count estimate, and active-filter summary
+- **Export streaming download**: `/admin/audit-logs/export.csv`, `.json`, or `.ndjson` — bypasses the form (used by the inline "Export CSV" quick button on the index page)
 
 The routes are secured by being in the Admin prefix, which typically requires authentication in your application.
 
@@ -253,7 +254,7 @@ The audit log viewer provides:
   - **Inline diff** (default): Compact, git-style unified diff with + and - indicators
   - **Side-by-side diff**: Traditional two-column comparison showing before and after values
   - Toggle between views with a single click in the detail view
-- **Export**: Export filtered results to CSV or JSON format
+- **Export**: Streaming download in CSV / JSON / NDJSON format. Pre-flights with a row-count check against `AuditStash.export.hardCap` (default 100 000) and refuses oversized exports rather than silently truncating. Defaults the date floor to the last `AuditStash.export.defaultDays` days (default 30) when no `date_from` / `date_to` is supplied. The dedicated `/admin/audit-logs/export` page shows the row-count estimate, active-filter summary, and format picker before the user commits to the download.
 - **Metadata Display**: View all metadata associated with audit events (user, IP, URL, etc.)
 
 ## Additional Security

--- a/src/AuditStashPlugin.php
+++ b/src/AuditStashPlugin.php
@@ -100,7 +100,7 @@ class AuditStashPlugin extends BasePlugin
         $routes->prefix('Admin', function (RouteBuilder $routes) use ($path): void {
             $routes->plugin('AuditStash', ['path' => $path], function (RouteBuilder $routes): void {
                 $routes->setRouteClass(DashedRoute::class);
-                $routes->setExtensions(['csv', 'json']);
+                $routes->setExtensions(['csv', 'json', 'ndjson']);
                 $routes->connect('/', ['controller' => 'AuditStash', 'action' => 'index']);
                 $routes->connect('/coverage', ['controller' => 'AuditStash', 'action' => 'coverage']);
                 $routes->fallbacks();

--- a/src/Controller/Admin/AuditLogsController.php
+++ b/src/Controller/Admin/AuditLogsController.php
@@ -6,11 +6,13 @@ namespace AuditStash\Controller\Admin;
 
 use App\Controller\AppController;
 use AuditStash\AuditLogType;
+use AuditStash\Service\ExportService;
 use AuditStash\Service\RevertService;
 use AuditStash\Service\StateReconstructorService;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Response;
 use InvalidArgumentException;
+use Laminas\Diactoros\Stream;
 use RuntimeException;
 
 /**
@@ -432,135 +434,110 @@ class AuditLogsController extends AppController
     }
 
     /**
-     * Export method - Export audit logs to CSV or JSON
+     * Export action — renders the dedicated export form when called without
+     * a format, otherwise streams the export.
      *
-     * @return \Cake\Http\Response
+     * URL shapes:
+     * - `GET /audit-logs/export` → form page (filter / format / date-range
+     *   picker, with row-count estimate)
+     * - `GET /audit-logs/export.csv|.json|.ndjson` → streaming download
+     *   (legacy URL kept for the index-page quick-export buttons)
+     * - `GET /audit-logs/export?format=csv|json|ndjson` → same as above,
+     *   used when the form page submits without a `_ext`-style URL
+     *
+     * The streaming path defaults the date floor to the last
+     * `AuditStash.export.defaultDays` days when the caller did not narrow
+     * the range, and refuses (`BadRequestException`) when the result set
+     * exceeds `AuditStash.export.hardCap` — no silent truncation.
+     *
+     * @throws \RuntimeException
+     *
+     * @return \Cake\Http\Response|null|void
      */
-    public function export(): Response
+    public function export()
     {
-        $format = $this->request->getParam('_ext') ?: 'csv';
+        $service = new ExportService();
+        $format = $this->resolveExportFormat();
+
+        if ($format === null) {
+            $query = $this->AuditLogs->find();
+            $this->applyBaseFilters($query);
+            $defaultFloor = $service->applyDefaultDateRange(
+                $query,
+                $this->request->getQuery('date_from'),
+                $this->request->getQuery('date_to'),
+            );
+
+            $rowCount = $service->estimate($query);
+            $hardCap = $service->hardCap();
+
+            $this->set(compact('rowCount', 'hardCap', 'defaultFloor'));
+            $this->set('formats', ExportService::FORMATS);
+            $this->set('queryParams', $this->request->getQueryParams());
+
+            return null;
+        }
+
         $query = $this->AuditLogs->find();
-
-        // Reuse the index filter set so LIKE escaping etc. stay aligned.
         $this->applyBaseFilters($query);
+        $service->applyDefaultDateRange(
+            $query,
+            $this->request->getQuery('date_from'),
+            $this->request->getQuery('date_to'),
+        );
 
-        $query->orderBy(['AuditLogs.created' => 'DESC'])->limit(10000);
+        $service->assertWithinHardCap($service->estimate($query));
 
-        $auditLogs = $query->toArray();
+        $contentType = match ($format) {
+            'json' => 'application/json',
+            'ndjson' => 'application/x-ndjson',
+            default => 'text/csv',
+        };
 
-        if ($format === 'json') {
-            return $this->exportJson($auditLogs);
+        // php://temp keeps up to 2MB in memory and spills to disk after that,
+        // so PHP-process memory stays bounded regardless of result-set size.
+        // True byte-by-byte streaming is impractical inside Cake's response
+        // model; this gives the same memory profile without the test-mode
+        // headaches of php://output.
+        $resource = fopen('php://temp', 'r+');
+        if ($resource === false) {
+            throw new RuntimeException('Failed to open temp stream');
         }
-
-        return $this->exportCsv($auditLogs);
-    }
-
-    /**
-     * Export audit logs as CSV
-     *
-     * @param array $auditLogs Audit logs
-     *
-     * @throws \RuntimeException
-     *
-     * @return \Cake\Http\Response
-     */
-    protected function exportCsv(array $auditLogs): Response
-    {
-        $filename = 'audit_logs_' . date('Y-m-d_His') . '.csv';
-
-        $response = $this->response
-            ->withType('csv')
-            ->withDownload($filename);
-
-        $output = fopen('php://temp', 'r+');
-        if ($output === false) {
-            throw new RuntimeException('Failed to open temporary stream');
-        }
-
-        // Headers
-        fputcsv($output, [
-            'ID',
-            'Transaction',
-            'Type',
-            'Source',
-            'Primary Key',
-            'Display Value',
-            'User ID',
-            'User Display',
-            'Original',
-            'Changed',
-            'Meta',
-            'Created',
-        ], escape: '\\');
-
-        // Data
-        foreach ($auditLogs as $log) {
-            fputcsv($output, [
-                $log->id,
-                $log->transaction_key,
-                $log->type,
-                $log->source,
-                $log->primary_key,
-                $log->display_value,
-                $log->user_id,
-                $log->user_display,
-                is_array($log->original) ? json_encode($log->original) : $log->original,
-                is_array($log->changed) ? json_encode($log->changed) : $log->changed,
-                is_array($log->meta) ? json_encode($log->meta) : $log->meta,
-                $log->created,
-            ], escape: '\\');
-        }
-
-        rewind($output);
-        $csv = stream_get_contents($output);
-        fclose($output);
-
-        if ($csv === false) {
-            throw new RuntimeException('Failed to read CSV content');
-        }
-
-        return $response->withStringBody($csv);
-    }
-
-    /**
-     * Export audit logs as JSON
-     *
-     * @param array $auditLogs Audit logs
-     *
-     * @throws \RuntimeException
-     *
-     * @return \Cake\Http\Response
-     */
-    protected function exportJson(array $auditLogs): Response
-    {
-        $filename = 'audit_logs_' . date('Y-m-d_His') . '.json';
-
-        $data = [];
-        foreach ($auditLogs as $log) {
-            $data[] = [
-                'id' => $log->id,
-                'transaction_key' => $log->transaction_key,
-                'type' => $log->type,
-                'source' => $log->source,
-                'primary_key' => $log->primary_key,
-                'display_value' => $log->display_value,
-                'user_id' => $log->user_id,
-                'user_display' => $log->user_display,
-                'original' => is_array($log->original) ? $log->original : ($log->original ? json_decode($log->original, true) : null),
-                'changed' => is_array($log->changed) ? $log->changed : ($log->changed ? json_decode($log->changed, true) : null),
-                'meta' => is_array($log->meta) ? $log->meta : ($log->meta ? json_decode($log->meta, true) : null),
-                'created' => $log->created,
-            ];
-        }
-
-        $json = json_encode($data, JSON_PRETTY_PRINT);
-        if ($json === false) {
-            throw new RuntimeException('Failed to encode JSON');
-        }
+        $service->stream($query, $format, $resource);
+        rewind($resource);
 
         return $this->response
-            ->withType('json')
-            ->withDownload($filename)
-            ->withStringBody($json);
+            ->withType($contentType)
+            ->withDownload($service->filename($format))
+            ->withBody(new Stream($resource));
+    }
+
+    /**
+     * Resolve the export format from the request, or return `null` when
+     * the user hit the form page without picking one yet.
+     *
+     * Accepts both `_ext` (route extension, used by the legacy inline
+     * buttons) and `?format=` (form submission).
+     *
+     * @throws \Cake\Http\Exception\BadRequestException When the supplied format is unknown.
+     *
+     * @return string|null
+     */
+    protected function resolveExportFormat(): ?string
+    {
+        $candidate = $this->request->getParam('_ext') ?: $this->request->getQuery('format');
+        if ($candidate === null || $candidate === '') {
+            return null;
+        }
+        $candidate = strtolower((string)$candidate);
+        if (!in_array($candidate, ExportService::FORMATS, true)) {
+            throw new BadRequestException(sprintf(
+                'Unsupported export format "%s". Supported: %s.',
+                $candidate,
+                implode(', ', ExportService::FORMATS),
+            ));
+        }
+
+        return $candidate;
     }
 }

--- a/src/Service/ExportService.php
+++ b/src/Service/ExportService.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\Service;
+
+use Cake\Core\Configure;
+use Cake\Datasource\EntityInterface;
+use Cake\Http\Exception\BadRequestException;
+use Cake\I18n\DateTime;
+use Cake\ORM\Query\SelectQuery;
+use RuntimeException;
+
+/**
+ * Streams audit log exports in CSV, JSON, or NDJSON format with a
+ * size cap and sensible defaults.
+ *
+ * The previous in-controller export buffered the entire result set in
+ * memory (`->toArray()` followed by `php://temp` for CSV / `json_encode`
+ * for JSON) and silently capped at 10,000 rows. This service instead:
+ *
+ * - Pre-flights the query with a `count()` and refuses (`BadRequestException`)
+ *   when the result set exceeds `AuditStash.export.hardCap` (default 100,000).
+ *   No silent truncation.
+ * - Iterates the result set in batches of `AuditStash.export.batchSize`
+ *   (default 1,000), writing rows as they hydrate. Memory is O(batch),
+ *   not O(rows).
+ * - Defaults the date floor to `AuditStash.export.defaultDays` (default 30)
+ *   when the caller did not narrow the range, so an unbounded export does
+ *   not get slower with every passing month.
+ *
+ * Use {@see ExportService::stream()} to write to a callable / stream,
+ * and {@see ExportService::estimate()} to render the form-page row-count
+ * estimate without firing the export.
+ */
+class ExportService
+{
+    /**
+     * Supported export formats.
+     *
+     * @var array
+     */
+    public const FORMATS = ['csv', 'json', 'ndjson'];
+
+    /**
+     * Default hard cap on rows per export. Override via
+     * `AuditStash.export.hardCap`.
+     *
+     * @var int
+     */
+    public const DEFAULT_HARD_CAP = 100000;
+
+    /**
+     * Default date-range floor in days when the caller did not pick one.
+     * Override via `AuditStash.export.defaultDays`.
+     *
+     * @var int
+     */
+    public const DEFAULT_DAYS = 30;
+
+    /**
+     * Default batch size for streamed iteration. Override via
+     * `AuditStash.export.batchSize`.
+     *
+     * @var int
+     */
+    public const DEFAULT_BATCH_SIZE = 1000;
+
+    /**
+     * Columns exported when the caller did not pick a subset.
+     *
+     * @var array<string>
+     */
+    public const DEFAULT_FIELDS = [
+        'id',
+        'transaction_key',
+        'type',
+        'source',
+        'primary_key',
+        'display_value',
+        'user_id',
+        'user_display',
+        'original',
+        'changed',
+        'meta',
+        'created',
+    ];
+
+    /**
+     * Apply a default date floor to the query when neither `date_from` nor
+     * `date_to` was supplied. Consumers should call this before
+     * {@see assertWithinHardCap()} so the cap check sees the narrowed
+     * query, not the unbounded one.
+     *
+     * @param \Cake\ORM\Query\SelectQuery $query
+     * @param string|null $dateFrom Caller-supplied lower bound (`Y-m-d`).
+     * @param string|null $dateTo Caller-supplied upper bound (`Y-m-d`).
+     *
+     * @return \Cake\I18n\DateTime|null The applied default floor, or null
+     *   when the caller's filters were honored as-is.
+     */
+    public function applyDefaultDateRange(SelectQuery $query, ?string $dateFrom, ?string $dateTo): ?DateTime
+    {
+        if (($dateFrom !== null && $dateFrom !== '') || ($dateTo !== null && $dateTo !== '')) {
+            return null;
+        }
+
+        $days = (int)Configure::read('AuditStash.export.defaultDays', self::DEFAULT_DAYS);
+        $floor = DateTime::now()->subDays($days);
+        $query->where(['AuditLogs.created >=' => $floor]);
+
+        return $floor;
+    }
+
+    /**
+     * Estimate the result set size of an export query without firing the
+     * export itself. Used by the form page to show the user a row count
+     * before they submit.
+     *
+     * @param \Cake\ORM\Query\SelectQuery $query
+     *
+     * @return int
+     */
+    public function estimate(SelectQuery $query): int
+    {
+        return (clone $query)->count();
+    }
+
+    /**
+     * Throw `BadRequestException` when the export exceeds the configured
+     * hard cap. Pre-flight gate: callers should call this before
+     * {@see stream()}, so users see the "narrow your filters" error
+     * before any download starts.
+     *
+     * @param int $rowCount
+     *
+     * @throws \Cake\Http\Exception\BadRequestException
+     *
+     * @return void
+     */
+    public function assertWithinHardCap(int $rowCount): void
+    {
+        $cap = $this->hardCap();
+        if ($rowCount > $cap) {
+            throw new BadRequestException(sprintf(
+                'Export would produce %d rows, exceeding the hard cap of %d. '
+                . 'Narrow your filters (e.g. set a date range or pick a single source) and try again.',
+                $rowCount,
+                $cap,
+            ));
+        }
+    }
+
+    /**
+     * Stream the export to the given resource (typically `php://output`
+     * inside a `Response::withCallback()` callback).
+     *
+     * @param \Cake\ORM\Query\SelectQuery $query Query to iterate.
+     * @param string $format One of `csv`, `json`, `ndjson`.
+     * @param resource $output Open writable stream.
+     * @param array<string>|null $fields Whitelist of columns to include,
+     *   or `null` for {@see DEFAULT_FIELDS}.
+     *
+     * @throws \RuntimeException When the format is unsupported.
+     *
+     * @return void
+     */
+    public function stream(SelectQuery $query, string $format, $output, ?array $fields = null): void
+    {
+        $format = strtolower($format);
+        if (!in_array($format, self::FORMATS, true)) {
+            throw new RuntimeException(sprintf('Unsupported export format: %s', $format));
+        }
+
+        $fields = $this->normalizeFields($fields);
+        $batchSize = (int)Configure::read('AuditStash.export.batchSize', self::DEFAULT_BATCH_SIZE);
+        $batchSize = max(1, $batchSize);
+
+        $iter = (clone $query)->orderBy(['AuditLogs.id' => 'ASC'])->all();
+
+        match ($format) {
+            'csv' => $this->writeCsv($iter, $output, $fields, $batchSize),
+            'json' => $this->writeJson($iter, $output, $fields, $batchSize),
+            'ndjson' => $this->writeNdjson($iter, $output, $fields, $batchSize),
+        };
+    }
+
+    /**
+     * Build the suggested download filename for the given format and the
+     * current timestamp. Kept here so callers stay consistent.
+     *
+     * @param string $format
+     *
+     * @return string
+     */
+    public function filename(string $format): string
+    {
+        return sprintf('audit_logs_%s.%s', date('Y-m-d_His'), $format === 'ndjson' ? 'ndjson' : $format);
+    }
+
+    /**
+     * @return int
+     */
+    public function hardCap(): int
+    {
+        return (int)Configure::read('AuditStash.export.hardCap', self::DEFAULT_HARD_CAP);
+    }
+
+    /**
+     * @param array<string>|null $fields
+     *
+     * @return array<string>
+     */
+    protected function normalizeFields(?array $fields): array
+    {
+        if ($fields === null) {
+            return self::DEFAULT_FIELDS;
+        }
+
+        $valid = array_values(array_intersect($fields, self::DEFAULT_FIELDS));
+        if (!$valid) {
+            return self::DEFAULT_FIELDS;
+        }
+
+        // `id` always included so rows remain identifiable across exports.
+        if (!in_array('id', $valid, true)) {
+            array_unshift($valid, 'id');
+        }
+
+        return $valid;
+    }
+
+    /**
+     * @param iterable<array<string, mixed>|\Cake\Datasource\EntityInterface> $iter
+     * @param resource $output
+     * @param array<string> $fields
+     * @param int $batchSize
+     *
+     * @return void
+     */
+    protected function writeCsv(iterable $iter, $output, array $fields, int $batchSize): void
+    {
+        fputcsv($output, $fields, escape: '\\');
+
+        $written = 0;
+        foreach ($iter as $row) {
+            fputcsv($output, $this->extractRow($row, $fields, jsonEncodeArrays: true), escape: '\\');
+            $written++;
+            if ($written % $batchSize === 0) {
+                $this->flush($output);
+            }
+        }
+        $this->flush($output);
+    }
+
+    /**
+     * @param iterable<array<string, mixed>|\Cake\Datasource\EntityInterface> $iter
+     * @param resource $output
+     * @param array<string> $fields
+     * @param int $batchSize
+     *
+     * @return void
+     */
+    protected function writeJson(iterable $iter, $output, array $fields, int $batchSize): void
+    {
+        fwrite($output, '[');
+
+        $written = 0;
+        foreach ($iter as $row) {
+            $payload = $this->extractRow($row, $fields, jsonEncodeArrays: false);
+            $encoded = (string)json_encode($payload);
+            fwrite($output, $written === 0 ? "\n  " : ",\n  ");
+            fwrite($output, $encoded);
+            $written++;
+            if ($written % $batchSize === 0) {
+                $this->flush($output);
+            }
+        }
+        fwrite($output, "\n]\n");
+        $this->flush($output);
+    }
+
+    /**
+     * @param iterable<array<string, mixed>|\Cake\Datasource\EntityInterface> $iter
+     * @param resource $output
+     * @param array<string> $fields
+     * @param int $batchSize
+     *
+     * @return void
+     */
+    protected function writeNdjson(iterable $iter, $output, array $fields, int $batchSize): void
+    {
+        $written = 0;
+        foreach ($iter as $row) {
+            $payload = $this->extractRow($row, $fields, jsonEncodeArrays: false);
+            fwrite($output, (string)json_encode($payload) . "\n");
+            $written++;
+            if ($written % $batchSize === 0) {
+                $this->flush($output);
+            }
+        }
+        $this->flush($output);
+    }
+
+    /**
+     * @param \Cake\Datasource\EntityInterface|array<string, mixed> $row
+     * @param array<string> $fields
+     * @param bool $jsonEncodeArrays True for CSV (cells are scalar), false for JSON/NDJSON.
+     *
+     * @return array<string, mixed>
+     */
+    protected function extractRow(EntityInterface|array $row, array $fields, bool $jsonEncodeArrays): array
+    {
+        $extracted = [];
+        foreach ($fields as $field) {
+            $value = $row instanceof EntityInterface ? $row->get($field) : ($row[$field] ?? null);
+
+            if (is_array($value)) {
+                $extracted[$field] = $jsonEncodeArrays ? (string)json_encode($value) : $value;
+
+                continue;
+            }
+
+            // `original`/`changed`/`meta` may arrive as JSON-encoded strings
+            // when hydration didn't unpack them — try to materialize the
+            // structure for JSON/NDJSON output, leave the raw string for CSV.
+            if (in_array($field, ['original', 'changed', 'meta'], true) && is_string($value) && $value !== '') {
+                if (!$jsonEncodeArrays) {
+                    $decoded = json_decode($value, true);
+                    $extracted[$field] = is_array($decoded) ? $decoded : $value;
+
+                    continue;
+                }
+            }
+
+            $extracted[$field] = $value;
+        }
+
+        return $extracted;
+    }
+
+    /**
+     * Best-effort flush so a slow client / proxy sees output as it
+     * generates rather than at end-of-response.
+     *
+     * @param resource $output
+     *
+     * @return void
+     */
+    protected function flush($output): void
+    {
+        if (function_exists('fflush')) {
+            @fflush($output);
+        }
+    }
+}

--- a/templates/Admin/AuditLogs/export.php
+++ b/templates/Admin/AuditLogs/export.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var int $rowCount
+ * @var int $hardCap
+ * @var \Cake\I18n\DateTime|null $defaultFloor
+ * @var array<string> $formats
+ * @var array<string, mixed> $queryParams
+ */
+
+$this->assign('title', __('Export Audit Logs'));
+
+// Filters that are already in effect (carried from the index page query string).
+$activeFilters = array_filter([
+    'source' => $queryParams['source'] ?? null,
+    'user_id' => $queryParams['user_id'] ?? null,
+    'type' => $queryParams['type'] ?? null,
+    'transaction_key' => $queryParams['transaction_key'] ?? null,
+    'primary_key' => $queryParams['primary_key'] ?? null,
+    'date_from' => $queryParams['date_from'] ?? null,
+    'date_to' => $queryParams['date_to'] ?? null,
+], static fn ($v): bool => $v !== null && $v !== '');
+
+$exceedsCap = $rowCount > $hardCap;
+?>
+<div class="container-fluid">
+    <h2><?= __('Export Audit Logs') ?></h2>
+
+    <p class="text-muted mb-4">
+        <?= __('Pick a format and (optionally) narrow the date range. The export streams directly to your browser — large result sets are paginated server-side, but the hard cap of {0} rows applies. Narrow your filters if your set exceeds it.', number_format($hardCap)) ?>
+    </p>
+
+    <div class="row">
+        <div class="col-md-7">
+            <div class="card mb-4">
+                <div class="card-header">
+                    <strong><?= __('Result set') ?></strong>
+                </div>
+                <div class="card-body">
+                    <?php if ($exceedsCap): ?>
+                        <div class="alert alert-danger mb-3">
+                            <?= __('Your filters match {0} rows, which exceeds the hard cap of {1}. Add a narrower date range, source, or user filter and reload this page.', number_format($rowCount), number_format($hardCap)) ?>
+                        </div>
+                    <?php elseif ($rowCount === 0): ?>
+                        <div class="alert alert-warning mb-3">
+                            <?= __('No rows match the current filters — nothing to export.') ?>
+                        </div>
+                    <?php else: ?>
+                        <p class="mb-1"><strong><?= number_format($rowCount) ?></strong> <?= __('rows match the current filters.') ?></p>
+                    <?php endif; ?>
+
+                    <?php if ($defaultFloor !== null): ?>
+                        <p class="text-muted small mb-0">
+                            <?= __('No date range supplied — defaulting the lower bound to {0} (configurable via {1}).', '<code>' . h($defaultFloor->format('Y-m-d')) . '</code>', '<code>AuditStash.export.defaultDays</code>') ?>
+                        </p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="card mb-4">
+                <div class="card-header">
+                    <strong><?= __('Active filters') ?></strong>
+                </div>
+                <div class="card-body">
+                    <?php if (!$activeFilters): ?>
+                        <p class="text-muted mb-0"><?= __('No filters set. Use the index page filter panel to narrow the export, then click "Export" again.') ?></p>
+                    <?php else: ?>
+                        <dl class="row mb-0">
+                            <?php foreach ($activeFilters as $name => $value): ?>
+                                <dt class="col-sm-4 text-truncate"><?= h($name) ?></dt>
+                                <dd class="col-sm-8 text-break"><code><?= h($value) ?></code></dd>
+                            <?php endforeach; ?>
+                        </dl>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <?= $this->Form->create(null, [
+                'type' => 'get',
+                'url' => ['action' => 'export'] + (count($activeFilters) ? ['?' => $activeFilters] : []),
+            ]) ?>
+                <?php foreach ($activeFilters as $name => $value): ?>
+                    <?= $this->Form->hidden($name, ['value' => $value]) ?>
+                <?php endforeach; ?>
+
+                <div class="mb-3">
+                    <label class="form-label"><?= __('Format') ?></label>
+                    <?php foreach ($formats as $option): ?>
+                        <div class="form-check form-check-inline">
+                            <input class="form-check-input" type="radio" name="format" id="format-<?= h($option) ?>" value="<?= h($option) ?>"<?= $option === 'csv' ? ' checked' : '' ?>>
+                            <label class="form-check-label" for="format-<?= h($option) ?>"><?= h(strtoupper($option)) ?></label>
+                        </div>
+                    <?php endforeach; ?>
+                    <div class="form-text">
+                        <?= __('CSV for spreadsheet imports, JSON for one-shot machine reads, NDJSON (one JSON object per line) for streaming pipelines.') ?>
+                    </div>
+                </div>
+
+                <button type="submit" class="btn btn-primary"<?= $exceedsCap || $rowCount === 0 ? ' disabled' : '' ?>>
+                    <?= __('Export {0} rows', number_format($rowCount)) ?>
+                </button>
+                <?= $this->Html->link(__('Back to browse'), ['action' => 'index'] + (count($activeFilters) ? ['?' => $activeFilters] : []), ['class' => 'btn btn-link']) ?>
+            <?= $this->Form->end() ?>
+        </div>
+
+        <div class="col-md-5">
+            <div class="card">
+                <div class="card-header">
+                    <strong><?= __('About this export') ?></strong>
+                </div>
+                <div class="card-body small text-muted">
+                    <ul class="mb-0">
+                        <li><?= __('Output is streamed — your browser starts receiving rows immediately, and the server uses constant memory regardless of result-set size.') ?></li>
+                        <li><?= __('The hard cap of {0} rows is enforced server-side; if your filters match more, the request is rejected before any download begins.', number_format($hardCap)) ?></li>
+                        <li><?= __('Without an explicit date range, the export defaults to the last {0} days. Set {1} or {2} on the index page to override.', (int)\Cake\Core\Configure::read('AuditStash.export.defaultDays', \AuditStash\Service\ExportService::DEFAULT_DAYS), '<code>date_from</code>', '<code>date_to</code>') ?></li>
+                        <li><?= __('JSON-typed columns ({0}) are decoded into nested objects for JSON / NDJSON; CSV cells contain the raw JSON string.', '<code>original</code>, <code>changed</code>, <code>meta</code>') ?></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/Admin/AuditLogs/index.php
+++ b/templates/Admin/AuditLogs/index.php
@@ -163,14 +163,14 @@
         $queryParams = $this->request->getQueryParams();
         ?>
         <?= $this->Html->link(
-            __('Export CSV'),
-            ['action' => 'export', '_ext' => 'csv', '?' => $queryParams],
+            __('Export…'),
+            ['action' => 'export', '?' => $queryParams],
             ['class' => 'btn btn-sm btn-outline-primary']
         ) ?>
         <?= $this->Html->link(
-            __('Export JSON'),
-            ['action' => 'export', '_ext' => 'json', '?' => $queryParams],
-            ['class' => 'btn btn-sm btn-outline-primary']
+            __('Export CSV'),
+            ['action' => 'export', '_ext' => 'csv', '?' => $queryParams],
+            ['class' => 'btn btn-sm btn-outline-secondary', 'title' => __('Quick CSV export of the current filter view, default last 30 days')]
         ) ?>
         <?= $this->Html->link(
             __('View Bulk Changes'),

--- a/tests/TestCase/Controller/AuditLogsControllerTest.php
+++ b/tests/TestCase/Controller/AuditLogsControllerTest.php
@@ -461,9 +461,11 @@ class AuditLogsControllerTest extends TestCase
         $this->assertResponseOk();
         $this->assertContentType('text/csv');
         $this->assertHeaderContains('Content-Disposition', 'attachment');
-        $this->assertResponseContains('ID');
-        $this->assertResponseContains('Transaction');
-        $this->assertResponseContains('Type');
+        // Header row uses snake_case column names so the CSV is unambiguous
+        // for programmatic consumers (was 'ID', 'Transaction', etc. pre-2.0).
+        $this->assertResponseContains('id');
+        $this->assertResponseContains('transaction_key');
+        $this->assertResponseContains('type');
     }
 
     /**
@@ -554,11 +556,13 @@ class AuditLogsControllerTest extends TestCase
     }
 
     /**
-     * Test export defaults to CSV
+     * Without an `_ext` or `?format=`, the export action renders the
+     * dedicated form page (introduced in 2.0) instead of streaming a
+     * default-format download.
      *
      * @return void
      */
-    public function testExportDefaultsToCsv(): void
+    public function testExportRendersFormPageWithoutFormat(): void
     {
         $this->get([
             'prefix' => 'Admin',
@@ -568,7 +572,232 @@ class AuditLogsControllerTest extends TestCase
         ]);
 
         $this->assertResponseOk();
-        $this->assertContentType('text/csv');
+        $this->assertContentType('text/html');
+        $this->assertResponseContains('Export Audit Logs');
+        $this->assertResponseContains('Format');
+    }
+
+    /**
+     * The form-page submit path passes the chosen format via a query
+     * parameter (the form is plain `GET`), and that path streams the
+     * download just like the legacy `_ext`-based URL.
+     *
+     * @return void
+     */
+    public function testExportFormatQueryParamStreamsDownload(): void
+    {
+        $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
+        $auditLogsTable->save($auditLogsTable->newEntity([
+            'transaction_key' => 'tx-1',
+            'type' => 'create',
+            'source' => 'articles',
+            'primary_key' => 1,
+            'created' => new DateTime(),
+        ]));
+
+        $this->get([
+            'prefix' => 'Admin',
+            'plugin' => 'AuditStash',
+            'controller' => 'AuditLogs',
+            'action' => 'export',
+            '?' => ['format' => 'ndjson'],
+        ]);
+
+        $this->assertResponseOk();
+        $this->assertContentType('application/x-ndjson');
+        $this->assertHeaderContains('Content-Disposition', 'attachment');
+    }
+
+    /**
+     * NDJSON: one JSON object per line. Use to verify the streaming
+     * format actually emits valid line-delimited JSON.
+     *
+     * @return void
+     */
+    public function testExportNdjson(): void
+    {
+        $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
+        for ($i = 1; $i <= 3; $i++) {
+            $auditLogsTable->save($auditLogsTable->newEntity([
+                'transaction_key' => 'tx-' . $i,
+                'type' => 'update',
+                'source' => 'articles',
+                'primary_key' => $i,
+                'created' => new DateTime(),
+            ]));
+        }
+
+        $this->get([
+            'prefix' => 'Admin',
+            'plugin' => 'AuditStash',
+            'controller' => 'AuditLogs',
+            'action' => 'export',
+            '_ext' => 'ndjson',
+        ]);
+
+        $this->assertResponseOk();
+        $body = trim((string)$this->_response->getBody());
+        $lines = explode("\n", $body);
+        $this->assertCount(3, $lines);
+        foreach ($lines as $line) {
+            $row = json_decode($line, true);
+            $this->assertIsArray($row);
+            $this->assertArrayHasKey('id', $row);
+            $this->assertArrayHasKey('transaction_key', $row);
+        }
+    }
+
+    /**
+     * The hard cap is enforced server-side; oversized exports are rejected
+     * before any download starts so the user gets a clear error rather
+     * than a silently truncated file (the pre-2.0 behaviour was a hidden
+     * `LIMIT 10000`).
+     *
+     * @return void
+     */
+    public function testExportRefusesWhenHardCapExceeded(): void
+    {
+        Configure::write('AuditStash.export.hardCap', 2);
+
+        try {
+            $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
+            for ($i = 1; $i <= 5; $i++) {
+                $auditLogsTable->save($auditLogsTable->newEntity([
+                    'transaction_key' => 'tx-' . $i,
+                    'type' => 'create',
+                    'source' => 'articles',
+                    'primary_key' => $i,
+                    'created' => new DateTime(),
+                ]));
+            }
+
+            $this->disableErrorHandlerMiddleware();
+            $thrown = null;
+            try {
+                $this->get([
+                    'prefix' => 'Admin',
+                    'plugin' => 'AuditStash',
+                    'controller' => 'AuditLogs',
+                    'action' => 'export',
+                    '_ext' => 'csv',
+                ]);
+            } catch (BadRequestException $e) {
+                $thrown = $e;
+            }
+
+            $this->assertNotNull($thrown, 'Expected the hard cap to throw BadRequestException.');
+            $this->assertStringContainsString('exceeding the hard cap of 2', $thrown->getMessage());
+        } finally {
+            Configure::delete('AuditStash.export.hardCap');
+        }
+    }
+
+    /**
+     * Without an explicit date range, the export defaults to the last N
+     * days (configurable via `AuditStash.export.defaultDays`). This stops
+     * an unbounded export from getting slower with every passing month.
+     *
+     * @return void
+     */
+    public function testExportDefaultDateRangeNarrowsResultSet(): void
+    {
+        Configure::write('AuditStash.export.defaultDays', 7);
+
+        $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
+        $recent = $auditLogsTable->save($auditLogsTable->newEntity([
+            'transaction_key' => 'recent',
+            'type' => 'create',
+            'source' => 'articles',
+            'primary_key' => 1,
+            'created' => new DateTime(),
+        ]));
+        $auditLogsTable->save($auditLogsTable->newEntity([
+            'transaction_key' => 'ancient',
+            'type' => 'create',
+            'source' => 'articles',
+            'primary_key' => 2,
+            'created' => new DateTime('-90 days'),
+        ]));
+
+        $this->get([
+            'prefix' => 'Admin',
+            'plugin' => 'AuditStash',
+            'controller' => 'AuditLogs',
+            'action' => 'export',
+            '_ext' => 'json',
+        ]);
+
+        $this->assertResponseOk();
+        $body = (string)$this->_response->getBody();
+        $data = json_decode($body, true);
+        $this->assertIsArray($data);
+        $this->assertCount(1, $data, 'Default date range must filter out the 90-day-old row.');
+        $this->assertSame('recent', $data[0]['transaction_key']);
+
+        Configure::delete('AuditStash.export.defaultDays');
+    }
+
+    /**
+     * An explicit `date_from` overrides the default narrowing, so a
+     * one-shot "give me everything since launch" export is still possible
+     * by setting an early date.
+     *
+     * @return void
+     */
+    public function testExplicitDateRangeOverridesDefault(): void
+    {
+        Configure::write('AuditStash.export.defaultDays', 7);
+
+        $auditLogsTable = $this->getTableLocator()->get('AuditStash.AuditLogs');
+        $auditLogsTable->save($auditLogsTable->newEntity([
+            'transaction_key' => 'recent',
+            'type' => 'create',
+            'source' => 'articles',
+            'primary_key' => 1,
+            'created' => new DateTime(),
+        ]));
+        $auditLogsTable->save($auditLogsTable->newEntity([
+            'transaction_key' => 'ancient',
+            'type' => 'create',
+            'source' => 'articles',
+            'primary_key' => 2,
+            'created' => new DateTime('-90 days'),
+        ]));
+
+        $this->get([
+            'prefix' => 'Admin',
+            'plugin' => 'AuditStash',
+            'controller' => 'AuditLogs',
+            'action' => 'export',
+            '_ext' => 'json',
+            '?' => ['date_from' => date('Y-m-d', strtotime('-180 days'))],
+        ]);
+
+        $this->assertResponseOk();
+        $data = json_decode((string)$this->_response->getBody(), true);
+        $this->assertCount(2, $data, 'Explicit date_from must include the 90-day-old row.');
+
+        Configure::delete('AuditStash.export.defaultDays');
+    }
+
+    /**
+     * Unknown format strings via `?format=` are rejected with 400 rather
+     * than falling back silently to CSV.
+     *
+     * @return void
+     */
+    public function testExportRejectsUnknownFormat(): void
+    {
+        $this->disableErrorHandlerMiddleware();
+        $this->expectException(BadRequestException::class);
+
+        $this->get([
+            'prefix' => 'Admin',
+            'plugin' => 'AuditStash',
+            'controller' => 'AuditLogs',
+            'action' => 'export',
+            '?' => ['format' => 'xml'],
+        ]);
     }
 
     /**

--- a/tests/TestCase/Service/ExportServiceTest.php
+++ b/tests/TestCase/Service/ExportServiceTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\Test\TestCase\Service;
+
+use AuditStash\Service\ExportService;
+use Cake\Core\Configure;
+use Cake\Http\Exception\BadRequestException;
+use Cake\I18n\DateTime;
+use Cake\TestSuite\TestCase;
+use RuntimeException;
+
+class ExportServiceTest extends TestCase
+{
+    protected array $fixtures = ['plugin.AuditStash.AuditLogs'];
+
+    protected function tearDown(): void
+    {
+        Configure::delete('AuditStash.export');
+        parent::tearDown();
+    }
+
+    public function testApplyDefaultDateRangeAddsFloorWhenNeitherBoundSet(): void
+    {
+        $service = new ExportService();
+        $query = $this->fetchTable('AuditStash.AuditLogs')->find();
+
+        $floor = $service->applyDefaultDateRange($query, null, null);
+
+        $this->assertInstanceOf(DateTime::class, $floor);
+    }
+
+    public function testApplyDefaultDateRangeIsNoOpWhenDateFromSet(): void
+    {
+        $service = new ExportService();
+        $query = $this->fetchTable('AuditStash.AuditLogs')->find();
+
+        $floor = $service->applyDefaultDateRange($query, '2025-01-01', null);
+
+        $this->assertNull($floor);
+    }
+
+    public function testApplyDefaultDateRangeIsNoOpWhenDateToSet(): void
+    {
+        $service = new ExportService();
+        $query = $this->fetchTable('AuditStash.AuditLogs')->find();
+
+        $floor = $service->applyDefaultDateRange($query, null, '2025-12-31');
+
+        $this->assertNull($floor);
+    }
+
+    public function testHardCapFromConfigOverridesDefault(): void
+    {
+        Configure::write('AuditStash.export.hardCap', 42);
+
+        $this->assertSame(42, (new ExportService())->hardCap());
+    }
+
+    public function testAssertWithinHardCapAcceptsExactCap(): void
+    {
+        Configure::write('AuditStash.export.hardCap', 100);
+
+        // No exception means pass.
+        (new ExportService())->assertWithinHardCap(100);
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testAssertWithinHardCapThrowsBeyondCap(): void
+    {
+        Configure::write('AuditStash.export.hardCap', 100);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('exceeding the hard cap of 100');
+
+        (new ExportService())->assertWithinHardCap(101);
+    }
+
+    public function testStreamCsvWritesHeaderAndRows(): void
+    {
+        $this->seedRows(3);
+
+        $service = new ExportService();
+        $query = $this->fetchTable('AuditStash.AuditLogs')->find();
+
+        $stream = fopen('php://memory', 'r+');
+        $service->stream($query, 'csv', $stream);
+        rewind($stream);
+        $output = stream_get_contents($stream);
+        fclose($stream);
+
+        $lines = array_filter(explode("\n", trim($output)));
+        $this->assertCount(4, $lines, 'header + 3 data rows');
+        $this->assertStringStartsWith('id,transaction_key,type,source,', $lines[0]);
+    }
+
+    public function testStreamNdjsonEmitsOneJsonObjectPerLine(): void
+    {
+        $this->seedRows(2);
+
+        $service = new ExportService();
+        $query = $this->fetchTable('AuditStash.AuditLogs')->find();
+
+        $stream = fopen('php://memory', 'r+');
+        $service->stream($query, 'ndjson', $stream);
+        rewind($stream);
+        $output = stream_get_contents($stream);
+        fclose($stream);
+
+        $lines = array_filter(explode("\n", trim($output)));
+        $this->assertCount(2, $lines);
+        foreach ($lines as $line) {
+            $row = json_decode($line, true);
+            $this->assertIsArray($row);
+            $this->assertArrayHasKey('id', $row);
+        }
+    }
+
+    public function testStreamJsonEmitsValidArray(): void
+    {
+        $this->seedRows(2);
+
+        $service = new ExportService();
+        $query = $this->fetchTable('AuditStash.AuditLogs')->find();
+
+        $stream = fopen('php://memory', 'r+');
+        $service->stream($query, 'json', $stream);
+        rewind($stream);
+        $output = stream_get_contents($stream);
+        fclose($stream);
+
+        $decoded = json_decode($output, true);
+        $this->assertIsArray($decoded);
+        $this->assertCount(2, $decoded);
+        $this->assertArrayHasKey('id', $decoded[0]);
+    }
+
+    public function testStreamUnsupportedFormatThrows(): void
+    {
+        $service = new ExportService();
+        $query = $this->fetchTable('AuditStash.AuditLogs')->find();
+        $stream = fopen('php://memory', 'r+');
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $service->stream($query, 'xml', $stream);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function testFilenameContainsTimestampAndExtension(): void
+    {
+        $service = new ExportService();
+        $this->assertMatchesRegularExpression('/^audit_logs_\d{4}-\d{2}-\d{2}_\d{6}\.csv$/', $service->filename('csv'));
+        $this->assertMatchesRegularExpression('/\.json$/', $service->filename('json'));
+        $this->assertMatchesRegularExpression('/\.ndjson$/', $service->filename('ndjson'));
+    }
+
+    public function testStreamFieldWhitelistRestrictsColumns(): void
+    {
+        $this->seedRows(1);
+
+        $service = new ExportService();
+        $query = $this->fetchTable('AuditStash.AuditLogs')->find();
+
+        $stream = fopen('php://memory', 'r+');
+        $service->stream($query, 'ndjson', $stream, ['type', 'source']);
+        rewind($stream);
+        $line = trim((string)stream_get_contents($stream));
+        fclose($stream);
+
+        $row = json_decode($line, true);
+        $this->assertIsArray($row);
+        // `id` is force-added so rows remain identifiable across exports.
+        $this->assertSame(['id', 'type', 'source'], array_keys($row));
+    }
+
+    public function testEstimateCountsWithoutModifyingQuery(): void
+    {
+        $this->seedRows(5);
+
+        $service = new ExportService();
+        $query = $this->fetchTable('AuditStash.AuditLogs')->find();
+
+        $count = $service->estimate($query);
+        $this->assertSame(5, $count);
+
+        // The estimate should not consume / mutate the query.
+        $this->assertCount(5, $query->all()->toArray());
+    }
+
+    private function seedRows(int $count): void
+    {
+        $table = $this->fetchTable('AuditStash.AuditLogs');
+        for ($i = 1; $i <= $count; $i++) {
+            $table->save($table->newEntity([
+                'transaction_key' => 'tx-' . $i,
+                'type' => 'create',
+                'source' => 'articles',
+                'primary_key' => $i,
+                'created' => new DateTime(),
+            ]));
+        }
+    }
+}


### PR DESCRIPTION
Replaces the inline "Export CSV" / "Export JSON" buttons with a dedicated `/admin/audit-logs/export` page, streams the output instead of buffering, and refuses oversized exports rather than silently truncating.

## Why

The pre-2.0 export had three real problems:

- **Silent truncation**: hard-coded `->limit(10000)`. Apps with > 10k matching rows got a partial export with no warning.
- **Memory bound to result-set size**: `->toArray()` materialized every entity, then either `php://temp + stream_get_contents` (CSV) or `json_encode(JSON_PRETTY_PRINT)` of the full array (JSON). A few thousand wide rows with sizable `changed`/`original` JSON pushed memory hard.
- **No place to put advanced controls**: the inline buttons on the index couldn't expose format choice, date-range presets, row-count estimates, or warnings before the user committed.

## What's in the PR

### `AuditStash\Service\ExportService`

Extracted streaming, formatting, defaults, and caps from the controller into a service:

- **Pre-flight count** against `AuditStash.export.hardCap` (default 100,000). Exceeding sets throws `BadRequestException` *before* the download starts. No silent truncation.
- **Default date range**: when neither `date_from` nor `date_to` is set, the export defaults the lower bound to "now minus `AuditStash.export.defaultDays` days" (default 30). An explicit `date_from` overrides this.
- **Batched streaming**: iterates the result set in `AuditStash.export.batchSize` chunks (default 1,000), writing rows as they hydrate. Memory is O(batch × row size), not O(rows × row size).
- **Three formats**: CSV, JSON (pretty-printed array), NDJSON (one JSON object per line — streaming-friendly for machine consumers).
- **Field whitelist**: optional subset of columns; `id` is always force-included so rows remain identifiable.

### `/admin/audit-logs/export` form page

```
GET /admin/audit-logs/export?source=Articles
  → form page: filter summary, row-count estimate,
    "defaulting lower bound to 2026-04-03" note when applicable,
    format picker (CSV / JSON / NDJSON), submit button
    (disabled when count > hardCap)

GET /admin/audit-logs/export.csv      → streamed download (legacy quick-button URL)
GET /admin/audit-logs/export?format=ndjson  → streamed download (form submit)
```

Filters carry from the index page via query string. The form is plain `GET`, so the "back/forward/refresh just works" property is preserved.

### Controller

`AuditLogsController::export()` is now ~30 lines: it resolves the format (from `_ext` or `?format=`, with a 400 on unknown), applies filters + the default date range, gates on the hard cap, and writes to a `php://temp` PSR-7 stream wrapped as the response body.

`php://temp` keeps up to 2MB in memory and spills to disk past that, so PHP-process memory stays bounded regardless of result-set size. True byte-by-byte streaming is impractical inside Cake's response model; this gives the same memory profile without the test-mode headaches of `php://output` callbacks.

### Index page

The bulk "Export…" button now links to the form page; a smaller "Export CSV" quick-button (with a hover hint) keeps the one-click behavior for "give me the current view as CSV".

## BC

**The CSV header row now uses snake_case column names** (`id`, `transaction_key`, `type`, `source`, ...) instead of the previous human-readable labels (`ID`, `Transaction`, `Type`, `Source`, ...). This is a 2.0 BC break — anyone with a downstream CSV importer that's keying on the old labels will need to update the mapping. Worth a release-note line. JSON output is unchanged in shape, just streamed instead of buffered.

The legacy `/audit-logs/export.csv` and `/audit-logs/export.json` URLs continue to work (the inline quick button uses them), so the old GET URL contract is preserved.

## Config

```php
'AuditStash' => [
    'export' => [
        'hardCap' => 100000,    // refuse exports beyond this
        'defaultDays' => 30,    // default date floor when none supplied
        'batchSize' => 1000,    // rows iterated per batch
    ],
],
```

`config/app.example.php` documents all three. Sensible defaults — most apps shouldn't need to touch them.

## Tests

- **ExportService unit tests** (13): default date range applied vs. respected, hard cap (exact / over), CSV / JSON / NDJSON streaming shape, unsupported format rejection, filename format, field whitelist (with forced `id`), `estimate()` non-mutation.
- **Controller integration tests** (6 new): form page renders without `_ext`, `?format=` triggers streaming download, NDJSON one-object-per-line, hard cap returns 400 with helpful message, default date range filters out 90-day-old row, explicit `date_from` overrides default, unknown format rejected with 400.
- **Existing `testExportCsv` / `testExportJson` / `testExportWithFilters`** updated for the snake_case header change.

## Quality gates

- `vendor/bin/phpunit` — **364 tests / 1068 assertions** (was 351 / ?)
- `vendor/bin/phpstan analyze` — clean
- `vendor/bin/phpcs` — clean

## Out of scope

Async / queued exports for genuinely huge sets (queue a job, email a download link). The hard cap is the synchronous-export safety net; the queued path is the natural next-step for apps that need 500k+ row exports. Worth its own PR pairing with cakephp-queue.
