### PR TITLE
Update sidebar / mobile-nav / index export links to the form page

### DIFF
--- a/templates/Admin/AuditLogs/index.php
+++ b/templates/Admin/AuditLogs/index.php
@@ -168,11 +168,6 @@
             ['class' => 'btn btn-sm btn-outline-primary']
         ) ?>
         <?= $this->Html->link(
-            __('Export CSV'),
-            ['action' => 'export', '_ext' => 'csv', '?' => $queryParams],
-            ['class' => 'btn btn-sm btn-outline-secondary', 'title' => __('Quick CSV export of the current filter view, default last 30 days')]
-        ) ?>
-        <?= $this->Html->link(
             __('View Bulk Changes'),
             ['action' => 'bulkChanges'],
             ['class' => 'btn btn-sm btn-outline-secondary']

--- a/templates/element/AuditStash/mobile_nav.php
+++ b/templates/element/AuditStash/mobile_nav.php
@@ -87,14 +87,9 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
             <div class="text-white-50 small text-uppercase mb-2"><?= __('Export') ?></div>
             <nav class="nav flex-column">
                 <a class="nav-link text-white-50"
-                   href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'export', '_ext' => 'csv']) ?>">
-                    <i class="fas fa-file-csv me-2"></i>
-                    <?= __('Export CSV') ?>
-                </a>
-                <a class="nav-link text-white-50"
-                   href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'export', '_ext' => 'json']) ?>">
-                    <i class="fas fa-file-code me-2"></i>
-                    <?= __('Export JSON') ?>
+                   href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'export']) ?>">
+                    <i class="fas fa-file-export me-2"></i>
+                    <?= __('Export…') ?>
                 </a>
             </nav>
         </div>

--- a/templates/element/AuditStash/sidebar.php
+++ b/templates/element/AuditStash/sidebar.php
@@ -76,14 +76,9 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
         <div class="nav-section-title"><?= __('Export') ?></div>
         <nav class="nav flex-column">
             <a class="nav-link"
-               href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'export', '_ext' => 'csv']) ?>">
-                <?= $this->element('AuditStash.icon', ['name' => 'file-csv', 'fallback' => 'fas fa-file-csv']) ?>
-                <?= __('Export CSV') ?>
-            </a>
-            <a class="nav-link"
-               href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'export', '_ext' => 'json']) ?>">
-                <?= $this->element('AuditStash.icon', ['name' => 'file-code', 'fallback' => 'fas fa-file-code']) ?>
-                <?= __('Export JSON') ?>
+               href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'export']) ?>">
+                <?= $this->element('AuditStash.icon', ['name' => 'file-export', 'fallback' => 'fas fa-file-export']) ?>
+                <?= __('Export…') ?>
             </a>
         </nav>
     </div>


### PR DESCRIPTION
Followup to #58. Three nav entry points still pointed at the legacy `/export.csv` and `/export.json` direct-stream URLs and bypassed the new form (with its row-count estimate, format picker, and hard-cap pre-flight):

- `templates/element/AuditStash/sidebar.php` had separate **Export CSV** and **Export JSON** entries
- `templates/element/AuditStash/mobile_nav.php` had the same pair
- `templates/Admin/AuditLogs/index.php` still had a redundant **Export CSV** quick button alongside the new **Export…** entry

Collapsed all three into a single **Export…** link to the form page. The sidebar / mobile nav are global (no filter context), so going through the form is the right default — users see the 30-day default note and get a chance to widen / narrow before committing. The 'Export CSV' quick button on the index was redundant once the form is filter-aware: filters carry through the query string, so the form page already shows the user exactly what their current view would export, just with one extra (worthwhile) click to see the count.

Streaming CSV / JSON / NDJSON download URLs themselves are unchanged and still work for direct linking / scripted use.

phpunit / phpstan / phpcs all green.