### PR TITLE
Fix coverage report linking the wrong source for plugin tables

### DIFF
--- a/src/Service/CoverageService.php
+++ b/src/Service/CoverageService.php
@@ -50,6 +50,7 @@ class CoverageService
     /**
      * @return array<int, array{
      *   alias: string,
+     *   source: string,
      *   class: ?string,
      *   plugin: ?string,
      *   has_behavior: bool,
@@ -84,10 +85,23 @@ class CoverageService
             }
 
             $inspection = $this->inspectClass($alias);
+
+            // Resolve the audit-log source for this class. AuditLogBehavior
+            // persists the source as `$_table->getRegistryAlias()`, which
+            // for plugin tables can be either `Plugin.Table` (when loaded
+            // with the dotted alias) or just `Table` (when loaded without
+            // the prefix from app code or via association). Pick whichever
+            // form actually has events; the dotted form wins when both
+            // forms have rows.
             $events = $eventCounts[$alias] ?? 0;
-            // Plugin-prefixed aliases also match unprefixed audit-log sources.
+            $source = $alias;
             if ($events === 0 && $info['plugin'] !== null) {
-                $events = $eventCounts[$info['short_alias']] ?? 0;
+                $shortEvents = $eventCounts[$info['short_alias']] ?? 0;
+                if ($shortEvents > 0) {
+                    $events = $shortEvents;
+                    $source = $info['short_alias'];
+                    $seenAliases[$info['short_alias']] = true;
+                }
             }
 
             $status = $isInternal
@@ -96,6 +110,7 @@ class CoverageService
 
             $rows[] = [
                 'alias' => $alias,
+                'source' => $source,
                 'class' => $info['class'],
                 'plugin' => $info['plugin'],
                 'has_behavior' => $inspection['has_behavior'],
@@ -114,6 +129,7 @@ class CoverageService
             }
             $rows[] = [
                 'alias' => $source,
+                'source' => $source,
                 'class' => null,
                 'plugin' => null,
                 'has_behavior' => false,

--- a/templates/Admin/AuditStash/coverage.php
+++ b/templates/Admin/AuditStash/coverage.php
@@ -3,6 +3,7 @@
  * @var \App\View\AppView $this
  * @var array<int, array{
  *   alias: string,
+ *   source: string,
  *   class: ?string,
  *   plugin: ?string,
  *   has_behavior: bool,
@@ -115,7 +116,14 @@ $chip = function (string $key, string $label, int $count) use ($filter, $include
                     <?php foreach ($rows as $row) { ?>
                         <tr>
                             <td><?= $badge($row['status']) ?></td>
-                            <td><code><?= h($row['alias']) ?></code></td>
+                            <td>
+                                <code><?= h($row['alias']) ?></code>
+                                <?php if (!empty($row['source']) && $row['source'] !== $row['alias']) { ?>
+                                    <div class="small text-muted">
+                                        <?= __('audit source: {0}', '<code>' . h($row['source']) . '</code>') ?>
+                                    </div>
+                                <?php } ?>
+                            </td>
                             <td><?= $row['plugin'] !== null ? '<code>' . h($row['plugin']) . '</code>' : '<span class="text-muted">—</span>' ?></td>
                             <td>
                                 <?php if ($row['class']) { ?>
@@ -132,7 +140,7 @@ $chip = function (string $key, string $label, int $count) use ($filter, $include
                                 <?php if ($row['events_30d'] > 0) { ?>
                                     <?= $this->Html->link(
                                         __('View activity'),
-                                        ['controller' => 'AuditLogs', 'action' => 'index', '?' => ['source' => $row['alias']]],
+                                        ['controller' => 'AuditLogs', 'action' => 'index', '?' => ['source' => $row['source'] ?? $row['alias']]],
                                         ['class' => 'btn btn-sm btn-link p-0'],
                                     ) ?>
                                 <?php } ?>

--- a/tests/TestCase/Service/CoverageServiceTest.php
+++ b/tests/TestCase/Service/CoverageServiceTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AuditStash\Test\TestCase\Service;
+
+use AuditStash\Service\CoverageService;
+use Cake\I18n\DateTime;
+use Cake\TestSuite\TestCase;
+
+class CoverageServiceTest extends TestCase
+{
+    protected array $fixtures = ['plugin.AuditStash.AuditLogs'];
+
+    /**
+     * Plugin tables can be registered in CakePHP under either the dotted
+     * alias (`Comments.Comments`) or the bare short alias (`Comments`),
+     * depending on how the table was first loaded — `fetchTable()` with
+     * the prefix vs. associations from app code without it.
+     * `AuditLogBehavior` persists the source as `getRegistryAlias()`, so
+     * the same logical table can show up in `audit_logs` under either
+     * form.
+     *
+     * The coverage report's "View activity" link must use the form that
+     * actually has rows. Before this regression test it always linked to
+     * the dotted alias, so when the plugin's audit rows lived under the
+     * short alias the link found nothing.
+     *
+     * @return void
+     */
+    public function testRowResolvesShortAliasSourceWhenDottedFormHasNoEvents(): void
+    {
+        $auditLogs = $this->fetchTable('AuditStash.AuditLogs');
+        $auditLogs->save($auditLogs->newEntity([
+            'transaction_key' => 'tx-1',
+            'type' => 'create',
+            'source' => 'AuditLogs',
+            'primary_key' => 1,
+            'created' => new DateTime(),
+        ]));
+
+        $service = new class extends CoverageService {
+            protected function discoverClasses(): array
+            {
+                return [
+                    // Pretend AuditLogs is a plugin-prefixed table — so we
+                    // exercise the "dotted alias has no events, fall back
+                    // to short alias" branch without needing a real
+                    // app-level plugin in the test fixtures.
+                    'AuditStash.AuditLogs' => [
+                        'class' => 'AuditStash\\Model\\Table\\AuditLogsTable',
+                        'plugin' => 'AuditStash',
+                        'short_alias' => 'AuditLogs',
+                    ],
+                ];
+            }
+        };
+
+        $rows = $service->discover(includeInternal: true);
+        $this->assertCount(1, $rows);
+        $row = $rows[0];
+
+        $this->assertSame('AuditStash.AuditLogs', $row['alias']);
+        $this->assertSame('AuditLogs', $row['source'], 'Link must point at the form audit_logs actually used.');
+        $this->assertSame(1, $row['events_30d']);
+    }
+
+    /**
+     * When the dotted form has its own rows (e.g. an installation that
+     * consistently loads via `fetchTable('Plugin.Table')`), the link
+     * stays on the dotted form — that's the more specific identifier,
+     * and the row count came from there.
+     *
+     * @return void
+     */
+    public function testRowKeepsDottedSourceWhenDottedFormHasEvents(): void
+    {
+        $auditLogs = $this->fetchTable('AuditStash.AuditLogs');
+        $auditLogs->save($auditLogs->newEntity([
+            'transaction_key' => 'tx-2',
+            'type' => 'create',
+            'source' => 'AuditStash.AuditLogs',
+            'primary_key' => 1,
+            'created' => new DateTime(),
+        ]));
+
+        $service = new class extends CoverageService {
+            protected function discoverClasses(): array
+            {
+                return [
+                    'AuditStash.AuditLogs' => [
+                        'class' => 'AuditStash\\Model\\Table\\AuditLogsTable',
+                        'plugin' => 'AuditStash',
+                        'short_alias' => 'AuditLogs',
+                    ],
+                ];
+            }
+        };
+
+        $rows = $service->discover(includeInternal: true);
+        $this->assertCount(1, $rows);
+        $this->assertSame('AuditStash.AuditLogs', $rows[0]['source']);
+    }
+
+    /**
+     * Plain (non-plugin) tables: alias and source are identical.
+     *
+     * @return void
+     */
+    public function testRowSourceMatchesAliasForNonPluginTables(): void
+    {
+        $auditLogs = $this->fetchTable('AuditStash.AuditLogs');
+        $auditLogs->save($auditLogs->newEntity([
+            'transaction_key' => 'tx-3',
+            'type' => 'create',
+            'source' => 'Articles',
+            'primary_key' => 1,
+            'created' => new DateTime(),
+        ]));
+
+        $service = new class extends CoverageService {
+            protected function discoverClasses(): array
+            {
+                return [
+                    'Articles' => [
+                        'class' => 'App\\Model\\Table\\ArticlesTable',
+                        'plugin' => null,
+                        'short_alias' => 'Articles',
+                    ],
+                ];
+            }
+        };
+
+        $rows = $service->discover(includeInternal: true);
+        $this->assertCount(1, $rows);
+        $this->assertSame('Articles', $rows[0]['alias']);
+        $this->assertSame('Articles', $rows[0]['source']);
+    }
+
+    /**
+     * When the same logical plugin table has rows under BOTH aliases (a
+     * messy state after a refactor), the dotted form is preferred — it's
+     * the more specific identifier, and a follow-up cleanup can decide
+     * what to do with the orphaned short-alias rows.
+     *
+     * @return void
+     */
+    public function testDottedFormWinsWhenBothAliasesHaveEvents(): void
+    {
+        $auditLogs = $this->fetchTable('AuditStash.AuditLogs');
+        $auditLogs->save($auditLogs->newEntity([
+            'transaction_key' => 'tx-dotted',
+            'type' => 'create',
+            'source' => 'AuditStash.AuditLogs',
+            'primary_key' => 1,
+            'created' => new DateTime(),
+        ]));
+        $auditLogs->save($auditLogs->newEntity([
+            'transaction_key' => 'tx-short',
+            'type' => 'create',
+            'source' => 'AuditLogs',
+            'primary_key' => 2,
+            'created' => new DateTime(),
+        ]));
+
+        $service = new class extends CoverageService {
+            protected function discoverClasses(): array
+            {
+                return [
+                    'AuditStash.AuditLogs' => [
+                        'class' => 'AuditStash\\Model\\Table\\AuditLogsTable',
+                        'plugin' => 'AuditStash',
+                        'short_alias' => 'AuditLogs',
+                    ],
+                ];
+            }
+        };
+
+        $rows = $service->discover(includeInternal: true);
+        // The dotted-form row has events on its own, so we don't fall
+        // back; the short-alias rows surface separately as 'empirical'
+        // (orphaned source — operator decides whether to backfill or
+        // delete them).
+        $byStatus = [];
+        foreach ($rows as $r) {
+            $byStatus[$r['status']][] = $r;
+        }
+
+        $this->assertCount(1, $byStatus['internal'] ?? [], 'Dotted-form class row.');
+        $this->assertSame('AuditStash.AuditLogs', $byStatus['internal'][0]['source']);
+        $this->assertSame(1, $byStatus['internal'][0]['events_30d']);
+
+        $this->assertCount(1, $byStatus['empirical'] ?? [], 'Short-alias rows surface as empirical.');
+        $this->assertSame('AuditLogs', $byStatus['empirical'][0]['source']);
+        $this->assertSame(1, $byStatus['empirical'][0]['events_30d']);
+    }
+}


### PR DESCRIPTION
## Bug

Coverage report row for a plugin table (e.g. `Comments.Comments`) was correctly counting events under both the dotted and short alias, but the **View activity** link was always built with `?source=Plugin.Table`. When the audit rows actually lived under `?source=Table` (the more common case in practice), the link found zero results.

## Why the source can be either form

`AuditLogBehavior::createEvent()` persists the source as `$this->_table->getRegistryAlias()`, which returns whatever alias the table was registered under in the locator:

- `$this->fetchTable('Comments.Comments')` → registry alias `Comments.Comments`
- `$this->fetchTable('Comments')` (from app code, or via association resolution from a non-plugin caller) → registry alias `Comments`

So the same logical plugin table can produce audit rows under either source string depending on the load path. The CoverageService already handled this on the count side but the template's link generation didn't get the same treatment.

## Fix

`CoverageService::discover()` now sets a `source` field on each row to the alias that actually has events (the dotted form when both are zero — that's still the better identifier). The template uses `$row['source']` for the link and shows a small "audit source: `<form>`" note when it differs from the displayed alias, so it's visible *why* the link goes where it does.

When BOTH aliases have rows (a messy state after a load-path refactor), the dotted form wins and the short-alias rows surface separately as `empirical` so the operator can decide whether to backfill or delete them.

## Docs (added in the merge commit)

`docs/usage.md` gets a new **"Plugin Tables and the `source` Column"** subsection covering:

- Why a plugin's audit rows can land under either form depending on locator load path
- The fragmented-trail problem when an app loads the same plugin table both ways at different times — and the recommendation to pick one form and stick with it
- The genuine collision case: app `App\Model\Table\CommentsTable` plus plugin `Comments\Model\Table\CommentsTable`, both writing rows under the bare `Comments` source. Solution: alias the plugin table in the locator so the source column carries a disambiguated name (`$locator->setConfig('PluginComments', ['className' => ...])`).

## Tests

Four new `CoverageServiceTest` cases:

- short-alias fallback (the bug case)
- dotted form preferred when it has events
- non-plugin tables (alias == source)
- both aliases populated → dotted wins, short surfaces as empirical

## Quality gates

- `vendor/bin/phpunit` — 389 tests / 1143 assertions
- `vendor/bin/phpstan analyze` — clean
- `vendor/bin/phpcs` — clean