### PR TITLE
Add admin header clock + debug-only Reset (truncate) button

### DIFF
--- a/src/Controller/Admin/AuditStashController.php
+++ b/src/Controller/Admin/AuditStashController.php
@@ -72,6 +72,8 @@ class AuditStashController extends AppController
      * demo environments — refuses to run when `Configure::read('debug')`
      * is false so a misconfigured route can't wipe production logs.
      *
+     * @throws \Cake\Http\Exception\ForbiddenException When debug is off.
+     *
      * @return \Cake\Http\Response|null
      */
     public function reset()

--- a/src/Controller/Admin/AuditStashController.php
+++ b/src/Controller/Admin/AuditStashController.php
@@ -7,6 +7,8 @@ namespace AuditStash\Controller\Admin;
 use App\Controller\AppController;
 use AuditStash\Service\CoverageService;
 use AuditStash\Service\DashboardService;
+use Cake\Core\Configure;
+use Cake\Http\Exception\ForbiddenException;
 
 /**
  * Plugin entry point. Hosts the admin dashboard (`index`) and the coverage
@@ -63,5 +65,27 @@ class AuditStashController extends AppController
         $summary = $service->summary();
 
         $this->set(compact('rows', 'filter', 'includeInternal', 'summary'));
+    }
+
+    /**
+     * Truncate audit_logs. Debug-only convenience for development /
+     * demo environments — refuses to run when `Configure::read('debug')`
+     * is false so a misconfigured route can't wipe production logs.
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function reset()
+    {
+        $this->request->allowMethod(['post']);
+        if (!Configure::read('debug')) {
+            throw new ForbiddenException('AuditStash reset is only available in debug mode.');
+        }
+
+        $connection = $this->AuditLogs->getConnection();
+        $connection->execute('TRUNCATE TABLE ' . $connection->getDriver()->quoteIdentifier($this->AuditLogs->getTable()));
+
+        $this->Flash->success(__('All audit logs have been deleted.'));
+
+        return $this->redirect(['action' => 'index']);
     }
 }

--- a/templates/element/AuditStash/sidebar.php
+++ b/templates/element/AuditStash/sidebar.php
@@ -82,4 +82,22 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
             </a>
         </nav>
     </div>
+
+    <?php if (\Cake\Core\Configure::read('debug')) { ?>
+    <div class="nav-section">
+        <div class="nav-section-title text-warning"><?= __('Debug') ?></div>
+        <nav class="nav flex-column">
+            <?= $this->Form->postLink(
+                $this->element('AuditStash.icon', ['name' => 'eraser', 'fallback' => 'fas fa-eraser']) . ' ' . __('Reset (truncate)'),
+                ['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditStash', 'action' => 'reset'],
+                [
+                    'class' => 'nav-link text-danger',
+                    'escapeTitle' => false,
+                    'confirm' => __('This wipes ALL audit log rows. Continue?'),
+                    'block' => true,
+                ],
+            ) ?>
+        </nav>
+    </div>
+    <?php } ?>
 </aside>

--- a/templates/layout/audit_stash.php
+++ b/templates/layout/audit_stash.php
@@ -347,8 +347,12 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
             <i class="fas fa-clipboard-list"></i>
             AuditStash Admin
         </a>
+        <span class="text-light small ms-auto me-3" title="<?= __d('audit_stash', 'Server Time') ?>">
+            <i class="far fa-clock me-1"></i>
+            <?= date('Y-m-d H:i:s') ?>
+        </span>
         <?php if ($hasBouncerPlugin) { ?>
-        <a class="btn btn-outline-light btn-sm ms-auto" href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index']) ?>">
+        <a class="btn btn-outline-light btn-sm" href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index']) ?>">
             <i class="fas fa-shield-alt me-1"></i>
             Bouncer
         </a>


### PR DESCRIPTION
Server-time clock in the admin header (mirrors the Queue admin header). Debug-only Reset button in the sidebar with a new AuditStashController::reset() action that TRUNCATEs audit_logs — refuses to run when Configure::read('debug') is false.