### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/audit_stash.pot
+++ b/resources/locales/audit_stash.pot
@@ -1,0 +1,519 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 01:53+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "Record reverted successfully."
+msgstr ""
+
+msgid "Failed to revert record."
+msgstr ""
+
+msgid "Record restored successfully."
+msgstr ""
+
+msgid "Failed to restore record."
+msgstr ""
+
+msgid "All audit logs have been deleted."
+msgstr ""
+
+msgid "User #{0}"
+msgstr ""
+
+msgid "Revert"
+msgstr ""
+
+msgid "Restore"
+msgstr ""
+
+msgid "No metadata available"
+msgstr ""
+
+msgid "No data available"
+msgstr ""
+
+msgid "Field"
+msgstr ""
+
+msgid "Value"
+msgstr ""
+
+msgid "Bulk Change Transactions"
+msgstr ""
+
+msgid "Showing transactions that affected {0} or more records."
+msgstr ""
+
+msgid "These may indicate bulk operations, imports, or mass updates."
+msgstr ""
+
+msgid "Back to Index"
+msgstr ""
+
+msgid "Minimum Records"
+msgstr ""
+
+msgid "Filter"
+msgstr ""
+
+msgid "No bulk change transactions found with {0} or more records."
+msgstr ""
+
+msgid "Transaction ID"
+msgstr ""
+
+msgid "Records"
+msgstr ""
+
+msgid "Tables Affected"
+msgstr ""
+
+msgid "User"
+msgstr ""
+
+msgid "Date/Time"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "View All"
+msgstr ""
+
+msgid "Legend:"
+msgstr ""
+
+msgid "records"
+msgstr ""
+
+msgid "Export Audit Logs"
+msgstr ""
+
+msgid "Pick a format and (optionally) narrow the date range. The export streams directly to your browser — large result sets are paginated server-side, but the hard cap of {0} rows applies. Narrow your filters if your set exceeds it."
+msgstr ""
+
+msgid "Result set"
+msgstr ""
+
+msgid "Your filters match {0} rows, which exceeds the hard cap of {1}. Add a narrower date range, source, or user filter and reload this page."
+msgstr ""
+
+msgid "No rows match the current filters — nothing to export."
+msgstr ""
+
+msgid "rows match the current filters."
+msgstr ""
+
+msgid "No date range supplied — defaulting the lower bound to {0} (configurable via {1})."
+msgstr ""
+
+msgid "Active filters"
+msgstr ""
+
+msgid "No filters set. Use the index page filter panel to narrow the export, then click \"Export\" again."
+msgstr ""
+
+msgid "Format"
+msgstr ""
+
+msgid "CSV for spreadsheet imports, JSON for one-shot machine reads, NDJSON (one JSON object per line) for streaming pipelines."
+msgstr ""
+
+msgid "Export {0} rows"
+msgstr ""
+
+msgid "Back to browse"
+msgstr ""
+
+msgid "About this export"
+msgstr ""
+
+msgid "Output is streamed — your browser starts receiving rows immediately, and the server uses constant memory regardless of result-set size."
+msgstr ""
+
+msgid "The hard cap of {0} rows is enforced server-side; if your filters match more, the request is rejected before any download begins."
+msgstr ""
+
+msgid "Without an explicit date range, the export defaults to the last {0} days. Set {1} or {2} on the index page to override."
+msgstr ""
+
+msgid "JSON-typed columns ({0}) are decoded into nested objects for JSON / NDJSON; CSV cells contain the raw JSON string."
+msgstr ""
+
+msgid "Audit Logs"
+msgstr ""
+
+msgid "Clear"
+msgstr ""
+
+msgid "Advanced Filters"
+msgstr ""
+
+msgid "Changed Field"
+msgstr ""
+
+msgid "Find records where this field was modified"
+msgstr ""
+
+msgid "Value Search"
+msgstr ""
+
+msgid "Find where field changed to specific value (both required)"
+msgstr ""
+
+msgid "Bulk Filter"
+msgstr ""
+
+msgid "Filter by transaction size (5+ records = bulk)"
+msgstr ""
+
+msgid "– All –"
+msgstr ""
+
+msgid "Bulk only"
+msgstr ""
+
+msgid "Non-bulk only"
+msgstr ""
+
+msgid "Export…"
+msgstr ""
+
+msgid "View Bulk Changes"
+msgstr ""
+
+msgid "View"
+msgstr ""
+
+msgid "Timeline"
+msgstr ""
+
+msgid "Related"
+msgstr ""
+
+msgid "Related Changes"
+msgstr ""
+
+msgid "Record:"
+msgstr ""
+
+msgid "Showing all audit logs for this record and related records (via foreign keys)."
+msgstr ""
+
+msgid "View Timeline"
+msgstr ""
+
+msgid "No related changes found."
+msgstr ""
+
+msgid "Transaction:"
+msgstr ""
+
+msgid "Event"
+msgstr ""
+
+msgid "Source"
+msgstr ""
+
+msgid "Record"
+msgstr ""
+
+msgid "Changes"
+msgstr ""
+
+msgid "Main"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "{0} record in this transaction"
+msgid_plural "{0} records in this transaction"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Restore Deleted Record"
+msgstr ""
+
+msgid "Back to List"
+msgstr ""
+
+msgid "Warning:"
+msgstr ""
+
+msgid "This will restore the record with the data shown above. If a record with this ID already exists, the restore will fail."
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Restore Record"
+msgstr ""
+
+msgid "Are you sure you want to restore this record?"
+msgstr ""
+
+msgid "No record data available to restore."
+msgstr ""
+
+msgid "No deletion record found for this record."
+msgstr ""
+
+msgid "Revert Preview"
+msgstr ""
+
+msgid "No differences found. Record is already in this state."
+msgstr ""
+
+msgid "Are you sure you want to revert the selected fields?"
+msgstr ""
+
+msgid "Fields to Revert"
+msgstr ""
+
+msgid "Select All"
+msgstr ""
+
+msgid "Select None"
+msgstr ""
+
+msgid "Revert Selected"
+msgstr ""
+
+msgid "Audit Timeline"
+msgstr ""
+
+msgid "View Details"
+msgstr ""
+
+msgid "Audit Log Details"
+msgstr ""
+
+msgid "Event Information"
+msgstr ""
+
+msgid "Event Type"
+msgstr ""
+
+msgid "Parent Source"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "Metadata"
+msgstr ""
+
+msgid "New Record"
+msgstr ""
+
+msgid "Deleted Record"
+msgstr ""
+
+msgid "Inline"
+msgstr ""
+
+msgid "Side-by-side"
+msgstr ""
+
+msgid "Created with values:"
+msgstr ""
+
+msgid "Deleted record had these values:"
+msgstr ""
+
+msgid "Event payload:"
+msgstr ""
+
+msgid "Audit Coverage"
+msgstr ""
+
+msgid "{0} of {1} discoverable tables have AuditLog behavior attached."
+msgstr ""
+
+msgid "← Dashboard"
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Tracked"
+msgstr ""
+
+msgid "Missing"
+msgstr ""
+
+msgid "Empirical"
+msgstr ""
+
+msgid "Include internal tables"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Alias"
+msgstr ""
+
+msgid "Plugin"
+msgstr ""
+
+msgid "Class"
+msgstr ""
+
+msgid "Events (30d)"
+msgstr ""
+
+msgid "No tables match this filter."
+msgstr ""
+
+msgid "audit source: {0}"
+msgstr ""
+
+msgid "No class found"
+msgstr ""
+
+msgid "View activity"
+msgstr ""
+
+msgid "Status legend"
+msgstr ""
+
+msgid "Class exists, AuditLog behavior attached."
+msgstr ""
+
+msgid "Class exists, behavior NOT attached — coverage gap."
+msgstr ""
+
+msgid "Events recorded for a source we couldn't map to a class — custom event source, renamed table, or plugin uninstalled."
+msgstr ""
+
+msgid "Internal"
+msgstr ""
+
+msgid "Hidden by deny-list — toggle above to include."
+msgstr ""
+
+msgid "Audit Dashboard"
+msgstr ""
+
+msgid "Activity, coverage, and integrity at a glance."
+msgstr ""
+
+msgid "Browse all logs"
+msgstr ""
+
+msgid "Events today"
+msgstr ""
+
+msgid "vs yesterday"
+msgstr ""
+
+msgid "Active users today"
+msgstr ""
+
+msgid "Active sources (7d)"
+msgstr ""
+
+msgid "distinct tables/sources with activity"
+msgstr ""
+
+msgid "Coverage"
+msgstr ""
+
+msgid "tables with AuditLog behavior"
+msgstr ""
+
+msgid "Events over time (last 30 days)"
+msgstr ""
+
+msgid "Other"
+msgstr ""
+
+msgid "Top sources (7 days)"
+msgstr ""
+
+msgid "No activity yet."
+msgstr ""
+
+msgid "Top users (7 days)"
+msgstr ""
+
+msgid "No user-attributed activity yet."
+msgstr ""
+
+msgid "(anonymous)"
+msgstr ""
+
+msgid "Recent activity"
+msgstr ""
+
+msgid "Open full log"
+msgstr ""
+
+msgid "When"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "Navigation"
+msgstr ""
+
+msgid "Dashboard"
+msgstr ""
+
+msgid "Bulk Changes"
+msgstr ""
+
+msgid "Quick Filters"
+msgstr ""
+
+msgid "Creates"
+msgstr ""
+
+msgid "Updates"
+msgstr ""
+
+msgid "Deletes"
+msgstr ""
+
+msgid "Export"
+msgstr ""
+
+msgid "Debug"
+msgstr ""
+
+msgid "Reset (truncate)"
+msgstr ""
+
+msgid "This wipes ALL audit log rows. Continue?"
+msgstr ""
+
+msgid "Page navigation"
+msgstr ""
+
+msgid "Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "Server Time"
+msgstr ""
+

--- a/src/Controller/Admin/AuditLogsController.php
+++ b/src/Controller/Admin/AuditLogsController.php
@@ -325,9 +325,9 @@ class AuditLogsController extends AppController
         }
 
         if ($entity) {
-            $this->Flash->success(__('Record reverted successfully.'));
+            $this->Flash->success(__d('audit_stash', 'Record reverted successfully.'));
         } else {
-            $this->Flash->error(__('Failed to revert record.'));
+            $this->Flash->error(__d('audit_stash', 'Failed to revert record.'));
         }
 
         $redirect = $this->redirect(['action' => 'view', $id]);
@@ -357,12 +357,12 @@ class AuditLogsController extends AppController
             $entity = $revertService->restoreDeleted($source, $primaryKey);
 
             if ($entity) {
-                $this->Flash->success(__('Record restored successfully.'));
+                $this->Flash->success(__d('audit_stash', 'Record restored successfully.'));
 
                 return $this->redirect(['action' => 'timeline', $source, $primaryKey]);
             }
 
-            $this->Flash->error(__('Failed to restore record.'));
+            $this->Flash->error(__d('audit_stash', 'Failed to restore record.'));
         }
 
         // Find DELETE audit entry for preview

--- a/src/Controller/Admin/AuditStashController.php
+++ b/src/Controller/Admin/AuditStashController.php
@@ -86,7 +86,7 @@ class AuditStashController extends AppController
         $connection = $this->AuditLogs->getConnection();
         $connection->execute('TRUNCATE TABLE ' . $connection->getDriver()->quoteIdentifier($this->AuditLogs->getTable()));
 
-        $this->Flash->success(__('All audit logs have been deleted.'));
+        $this->Flash->success(__d('audit_stash', 'All audit logs have been deleted.'));
 
         return $this->redirect(['action' => 'index']);
     }

--- a/src/View/Helper/AuditHelper.php
+++ b/src/View/Helper/AuditHelper.php
@@ -489,7 +489,7 @@ class AuditHelper extends Helper
         $isNumeric = ctype_digit($user);
 
         if ($isUuid || $isNumeric) {
-            return __('User #{0}', $user);
+            return __d('audit_stash', 'User #{0}', $user);
         }
 
         // Looks like a username/email, use as-is
@@ -615,7 +615,7 @@ class AuditHelper extends Helper
         $options += ['class' => 'btn btn-sm btn-warning'];
 
         return $this->Html->link(
-            __('Revert'),
+            __d('audit_stash', 'Revert'),
             ['action' => 'revertPreview', $auditLogId],
             $options,
         );
@@ -635,7 +635,7 @@ class AuditHelper extends Helper
         $options += ['class' => 'btn btn-sm btn-success'];
 
         return $this->Html->link(
-            __('Restore'),
+            __d('audit_stash', 'Restore'),
             ['action' => 'restore', $source, $primaryKey],
             $options,
         );
@@ -654,7 +654,7 @@ class AuditHelper extends Helper
             $meta = json_decode($meta, true);
         }
         if (!$meta || !is_array($meta)) {
-            return '<p class="text-muted">' . __('No metadata available') . '</p>';
+            return '<p class="text-muted">' . __d('audit_stash', 'No metadata available') . '</p>';
         }
 
         $rows = '';
@@ -684,7 +684,7 @@ class AuditHelper extends Helper
             $data = json_decode($data, true);
         }
         if (!$data || !is_array($data)) {
-            return '<p class="text-muted">' . __('No data available') . '</p>';
+            return '<p class="text-muted">' . __d('audit_stash', 'No data available') . '</p>';
         }
 
         $output = '';
@@ -693,7 +693,7 @@ class AuditHelper extends Helper
         }
 
         $output .= '<table class="table table-sm table-bordered">';
-        $output .= '<thead><tr><th style="width: 30%;">' . __('Field') . '</th><th>' . __('Value') . '</th></tr></thead>';
+        $output .= '<thead><tr><th style="width: 30%;">' . __d('audit_stash', 'Field') . '</th><th>' . __d('audit_stash', 'Value') . '</th></tr></thead>';
         $output .= '<tbody>';
 
         foreach ($data as $field => $value) {

--- a/templates/Admin/AuditLogs/bulk_changes.php
+++ b/templates/Admin/AuditLogs/bulk_changes.php
@@ -6,18 +6,18 @@
  */
 ?>
 <div class="auditLogs bulk-changes content">
-    <h3><?= __('Bulk Change Transactions') ?></h3>
+    <h3><?= __d('audit_stash', 'Bulk Change Transactions') ?></h3>
 
     <div class="alert alert-info">
         <p class="mb-0">
-            <?= __('Showing transactions that affected {0} or more records.', $minRecords) ?>
-            <?= __('These may indicate bulk operations, imports, or mass updates.') ?>
+            <?= __d('audit_stash', 'Showing transactions that affected {0} or more records.', $minRecords) ?>
+            <?= __d('audit_stash', 'These may indicate bulk operations, imports, or mass updates.') ?>
         </p>
     </div>
 
     <div class="mb-3">
         <?= $this->Html->link(
-            __('Back to Index'),
+            __d('audit_stash', 'Back to Index'),
             ['action' => 'index'],
             ['class' => 'btn btn-secondary']
         ) ?>
@@ -31,14 +31,14 @@
                 <div class="col-md-3">
                     <?= $this->Form->control('min_records', [
                         'type' => 'number',
-                        'label' => __('Minimum Records'),
+                        'label' => __d('audit_stash', 'Minimum Records'),
                         'default' => $minRecords,
                         'min' => 2,
                         'class' => 'form-control',
                     ]) ?>
                 </div>
                 <div class="col-md-3 d-flex align-items-end">
-                    <?= $this->Form->button(__('Filter'), ['class' => 'btn btn-primary']) ?>
+                    <?= $this->Form->button(__d('audit_stash', 'Filter'), ['class' => 'btn btn-primary']) ?>
                 </div>
             </div>
             <?= $this->Form->end() ?>
@@ -47,19 +47,19 @@
 
     <?php if (empty($bulkStats)) { ?>
         <div class="alert alert-warning">
-            <?= __('No bulk change transactions found with {0} or more records.', $minRecords) ?>
+            <?= __d('audit_stash', 'No bulk change transactions found with {0} or more records.', $minRecords) ?>
         </div>
     <?php } else { ?>
         <div class="table-responsive">
             <table class="table table-striped table-hover">
                 <thead>
                     <tr>
-                        <th><?= __('Transaction ID') ?></th>
-                        <th><?= __('Records') ?></th>
-                        <th><?= __('Tables Affected') ?></th>
-                        <th><?= __('User') ?></th>
-                        <th><?= __('Date/Time') ?></th>
-                        <th><?= __('Actions') ?></th>
+                        <th><?= __d('audit_stash', 'Transaction ID') ?></th>
+                        <th><?= __d('audit_stash', 'Records') ?></th>
+                        <th><?= __d('audit_stash', 'Tables Affected') ?></th>
+                        <th><?= __d('audit_stash', 'User') ?></th>
+                        <th><?= __d('audit_stash', 'Date/Time') ?></th>
+                        <th><?= __d('audit_stash', 'Actions') ?></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -80,7 +80,7 @@
                             <td><small><?= h($stat['created']) ?></small></td>
                             <td>
                                 <?= $this->Html->link(
-                                    __('View All'),
+                                    __d('audit_stash', 'View All'),
                                     ['action' => 'index', '?' => ['transaction_key' => $stat['transaction_key']]],
                                     ['class' => 'btn btn-sm btn-outline-primary']
                                 ) ?>
@@ -92,10 +92,10 @@
         </div>
 
         <div class="alert alert-secondary mt-3">
-            <strong><?= __('Legend:') ?></strong>
-            <span class="badge bg-info ms-2">&lt; 20</span> <?= __('records') ?>
-            <span class="badge bg-warning ms-2">20-99</span> <?= __('records') ?>
-            <span class="badge bg-danger ms-2">100+</span> <?= __('records') ?>
+            <strong><?= __d('audit_stash', 'Legend:') ?></strong>
+            <span class="badge bg-info ms-2">&lt; 20</span> <?= __d('audit_stash', 'records') ?>
+            <span class="badge bg-warning ms-2">20-99</span> <?= __d('audit_stash', 'records') ?>
+            <span class="badge bg-danger ms-2">100+</span> <?= __d('audit_stash', 'records') ?>
         </div>
     <?php } ?>
 </div>

--- a/templates/Admin/AuditLogs/export.php
+++ b/templates/Admin/AuditLogs/export.php
@@ -8,7 +8,7 @@
  * @var array<string, mixed> $queryParams
  */
 
-$this->assign('title', __('Export Audit Logs'));
+$this->assign('title', __d('audit_stash', 'Export Audit Logs'));
 
 // Filters that are already in effect (carried from the index page query string).
 // Whitelist must stay in sync with `AuditLogsController::resolveFilterParams()`,
@@ -33,34 +33,34 @@ $activeFilters = array_filter([
 $exceedsCap = $rowCount > $hardCap;
 ?>
 <div class="container-fluid">
-    <h2><?= __('Export Audit Logs') ?></h2>
+    <h2><?= __d('audit_stash', 'Export Audit Logs') ?></h2>
 
     <p class="text-muted mb-4">
-        <?= __('Pick a format and (optionally) narrow the date range. The export streams directly to your browser — large result sets are paginated server-side, but the hard cap of {0} rows applies. Narrow your filters if your set exceeds it.', number_format($hardCap)) ?>
+        <?= __d('audit_stash', 'Pick a format and (optionally) narrow the date range. The export streams directly to your browser — large result sets are paginated server-side, but the hard cap of {0} rows applies. Narrow your filters if your set exceeds it.', number_format($hardCap)) ?>
     </p>
 
     <div class="row">
         <div class="col-md-7">
             <div class="card mb-4">
                 <div class="card-header">
-                    <strong><?= __('Result set') ?></strong>
+                    <strong><?= __d('audit_stash', 'Result set') ?></strong>
                 </div>
                 <div class="card-body">
                     <?php if ($exceedsCap): ?>
                         <div class="alert alert-danger mb-3">
-                            <?= __('Your filters match {0} rows, which exceeds the hard cap of {1}. Add a narrower date range, source, or user filter and reload this page.', number_format($rowCount), number_format($hardCap)) ?>
+                            <?= __d('audit_stash', 'Your filters match {0} rows, which exceeds the hard cap of {1}. Add a narrower date range, source, or user filter and reload this page.', number_format($rowCount), number_format($hardCap)) ?>
                         </div>
                     <?php elseif ($rowCount === 0): ?>
                         <div class="alert alert-warning mb-3">
-                            <?= __('No rows match the current filters — nothing to export.') ?>
+                            <?= __d('audit_stash', 'No rows match the current filters — nothing to export.') ?>
                         </div>
                     <?php else: ?>
-                        <p class="mb-1"><strong><?= number_format($rowCount) ?></strong> <?= __('rows match the current filters.') ?></p>
+                        <p class="mb-1"><strong><?= number_format($rowCount) ?></strong> <?= __d('audit_stash', 'rows match the current filters.') ?></p>
                     <?php endif; ?>
 
                     <?php if ($defaultFloor !== null): ?>
                         <p class="text-muted small mb-0">
-                            <?= __('No date range supplied — defaulting the lower bound to {0} (configurable via {1}).', '<code>' . h($defaultFloor->format('Y-m-d')) . '</code>', '<code>AuditStash.export.defaultDays</code>') ?>
+                            <?= __d('audit_stash', 'No date range supplied — defaulting the lower bound to {0} (configurable via {1}).', '<code>' . h($defaultFloor->format('Y-m-d')) . '</code>', '<code>AuditStash.export.defaultDays</code>') ?>
                         </p>
                     <?php endif; ?>
                 </div>
@@ -68,11 +68,11 @@ $exceedsCap = $rowCount > $hardCap;
 
             <div class="card mb-4">
                 <div class="card-header">
-                    <strong><?= __('Active filters') ?></strong>
+                    <strong><?= __d('audit_stash', 'Active filters') ?></strong>
                 </div>
                 <div class="card-body">
                     <?php if (!$activeFilters): ?>
-                        <p class="text-muted mb-0"><?= __('No filters set. Use the index page filter panel to narrow the export, then click "Export" again.') ?></p>
+                        <p class="text-muted mb-0"><?= __d('audit_stash', 'No filters set. Use the index page filter panel to narrow the export, then click "Export" again.') ?></p>
                     <?php else: ?>
                         <dl class="row mb-0">
                             <?php foreach ($activeFilters as $name => $value): ?>
@@ -93,7 +93,7 @@ $exceedsCap = $rowCount > $hardCap;
                 <?php endforeach; ?>
 
                 <div class="mb-3">
-                    <label class="form-label"><?= __('Format') ?></label>
+                    <label class="form-label"><?= __d('audit_stash', 'Format') ?></label>
                     <?php foreach ($formats as $option): ?>
                         <div class="form-check form-check-inline">
                             <input class="form-check-input" type="radio" name="format" id="format-<?= h($option) ?>" value="<?= h($option) ?>"<?= $option === 'csv' ? ' checked' : '' ?>>
@@ -101,28 +101,28 @@ $exceedsCap = $rowCount > $hardCap;
                         </div>
                     <?php endforeach; ?>
                     <div class="form-text">
-                        <?= __('CSV for spreadsheet imports, JSON for one-shot machine reads, NDJSON (one JSON object per line) for streaming pipelines.') ?>
+                        <?= __d('audit_stash', 'CSV for spreadsheet imports, JSON for one-shot machine reads, NDJSON (one JSON object per line) for streaming pipelines.') ?>
                     </div>
                 </div>
 
                 <button type="submit" class="btn btn-primary"<?= $exceedsCap || $rowCount === 0 ? ' disabled' : '' ?>>
-                    <?= __('Export {0} rows', number_format($rowCount)) ?>
+                    <?= __d('audit_stash', 'Export {0} rows', number_format($rowCount)) ?>
                 </button>
-                <?= $this->Html->link(__('Back to browse'), ['action' => 'index'] + (count($activeFilters) ? ['?' => $activeFilters] : []), ['class' => 'btn btn-link']) ?>
+                <?= $this->Html->link(__d('audit_stash', 'Back to browse'), ['action' => 'index'] + (count($activeFilters) ? ['?' => $activeFilters] : []), ['class' => 'btn btn-link']) ?>
             <?= $this->Form->end() ?>
         </div>
 
         <div class="col-md-5">
             <div class="card">
                 <div class="card-header">
-                    <strong><?= __('About this export') ?></strong>
+                    <strong><?= __d('audit_stash', 'About this export') ?></strong>
                 </div>
                 <div class="card-body small text-muted">
                     <ul class="mb-0">
-                        <li><?= __('Output is streamed — your browser starts receiving rows immediately, and the server uses constant memory regardless of result-set size.') ?></li>
-                        <li><?= __('The hard cap of {0} rows is enforced server-side; if your filters match more, the request is rejected before any download begins.', number_format($hardCap)) ?></li>
-                        <li><?= __('Without an explicit date range, the export defaults to the last {0} days. Set {1} or {2} on the index page to override.', (int)\Cake\Core\Configure::read('AuditStash.export.defaultDays', \AuditStash\Service\ExportService::DEFAULT_DAYS), '<code>date_from</code>', '<code>date_to</code>') ?></li>
-                        <li><?= __('JSON-typed columns ({0}) are decoded into nested objects for JSON / NDJSON; CSV cells contain the raw JSON string.', '<code>original</code>, <code>changed</code>, <code>meta</code>') ?></li>
+                        <li><?= __d('audit_stash', 'Output is streamed — your browser starts receiving rows immediately, and the server uses constant memory regardless of result-set size.') ?></li>
+                        <li><?= __d('audit_stash', 'The hard cap of {0} rows is enforced server-side; if your filters match more, the request is rejected before any download begins.', number_format($hardCap)) ?></li>
+                        <li><?= __d('audit_stash', 'Without an explicit date range, the export defaults to the last {0} days. Set {1} or {2} on the index page to override.', (int)\Cake\Core\Configure::read('AuditStash.export.defaultDays', \AuditStash\Service\ExportService::DEFAULT_DAYS), '<code>date_from</code>', '<code>date_to</code>') ?></li>
+                        <li><?= __d('audit_stash', 'JSON-typed columns ({0}) are decoded into nested objects for JSON / NDJSON; CSV cells contain the raw JSON string.', '<code>original</code>, <code>changed</code>, <code>meta</code>') ?></li>
                     </ul>
                 </div>
             </div>

--- a/templates/Admin/AuditLogs/index.php
+++ b/templates/Admin/AuditLogs/index.php
@@ -8,7 +8,7 @@
  */
 ?>
 <div class="auditLogs index content">
-    <h3><?= __('Audit Logs') ?></h3>
+    <h3><?= __d('audit_stash', 'Audit Logs') ?></h3>
 
     <?php
     $hasAdvancedFilters = $this->request->getQuery('changed_field')
@@ -83,9 +83,9 @@
                     ]) ?>
                 </div>
                 <div class="col-md-3 d-flex align-items-end">
-                    <?= $this->Form->button(__('Filter'), ['class' => 'btn btn-primary me-2']) ?>
+                    <?= $this->Form->button(__d('audit_stash', 'Filter'), ['class' => 'btn btn-primary me-2']) ?>
                     <?php if ($this->request->getQueryParams()) { ?>
-                        <?= $this->Html->link(__('Clear'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
+                        <?= $this->Html->link(__d('audit_stash', 'Clear'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
                     <?php } ?>
                 </div>
             </div>
@@ -93,13 +93,13 @@
             <!-- Advanced Filters (collapsible) -->
             <div class="mt-3">
                 <a class="text-decoration-none" data-toggle="collapse" data-bs-toggle="collapse" href="#advancedFilters" role="button" aria-expanded="<?= $hasAdvancedFilters ? 'true' : 'false' ?>" aria-controls="advancedFilters">
-                    <small><?= __('Advanced Filters') ?> <span class="collapse-icon"><?= $hasAdvancedFilters ? '&#9660;' : '&#9654;' ?></span></small>
+                    <small><?= __d('audit_stash', 'Advanced Filters') ?> <span class="collapse-icon"><?= $hasAdvancedFilters ? '&#9660;' : '&#9654;' ?></span></small>
                 </a>
                 <div class="collapse<?= $hasAdvancedFilters ? ' show' : '' ?>" id="advancedFilters">
                     <div class="row g-3 mt-2">
                         <div class="col-md-3">
-                            <label class="form-label"><?= __('Changed Field') ?></label>
-                            <small class="text-muted d-block mb-1"><?= __('Find records where this field was modified') ?></small>
+                            <label class="form-label"><?= __d('audit_stash', 'Changed Field') ?></label>
+                            <small class="text-muted d-block mb-1"><?= __d('audit_stash', 'Find records where this field was modified') ?></small>
                             <?= $this->Form->control('changed_field', [
                                 'type' => 'text',
                                 'label' => false,
@@ -114,8 +114,8 @@
                             </datalist>
                         </div>
                         <div class="col-md-5">
-                            <label class="form-label"><?= __('Value Search') ?></label>
-                            <small class="text-muted d-block mb-1"><?= __('Find where field changed to specific value (both required)') ?></small>
+                            <label class="form-label"><?= __d('audit_stash', 'Value Search') ?></label>
+                            <small class="text-muted d-block mb-1"><?= __d('audit_stash', 'Find where field changed to specific value (both required)') ?></small>
                             <div class="row g-2">
                                 <div class="col-6">
                                     <?= $this->Form->control('field_name', [
@@ -137,15 +137,15 @@
                             </div>
                         </div>
                         <div class="col-md-4">
-                            <label class="form-label"><?= __('Bulk Filter') ?></label>
-                            <small class="text-muted d-block mb-1"><?= __('Filter by transaction size (5+ records = bulk)') ?></small>
+                            <label class="form-label"><?= __d('audit_stash', 'Bulk Filter') ?></label>
+                            <small class="text-muted d-block mb-1"><?= __d('audit_stash', 'Filter by transaction size (5+ records = bulk)') ?></small>
                             <?= $this->Form->control('bulk_filter', [
                                 'type' => 'select',
                                 'label' => false,
                                 'options' => [
-                                    '' => __('– All –'),
-                                    'yes' => __('Bulk only'),
-                                    'no' => __('Non-bulk only'),
+                                    '' => __d('audit_stash', '– All –'),
+                                    'yes' => __d('audit_stash', 'Bulk only'),
+                                    'no' => __d('audit_stash', 'Non-bulk only'),
                                 ],
                                 'class' => 'form-select',
                             ]) ?>
@@ -163,12 +163,12 @@
         $queryParams = $this->request->getQueryParams();
         ?>
         <?= $this->Html->link(
-            __('Export…'),
+            __d('audit_stash', 'Export…'),
             ['action' => 'export', '?' => $queryParams],
             ['class' => 'btn btn-sm btn-outline-primary']
         ) ?>
         <?= $this->Html->link(
-            __('View Bulk Changes'),
+            __d('audit_stash', 'View Bulk Changes'),
             ['action' => 'bulkChanges'],
             ['class' => 'btn btn-sm btn-outline-secondary']
         ) ?>
@@ -185,7 +185,7 @@
                     <th><?= $this->Paginator->sort('primary_key', 'Record') ?></th>
                     <th><?= $this->Paginator->sort('user_id', 'User') ?></th>
                     <th>Changes</th>
-                    <th class="actions"><?= __('Actions') ?></th>
+                    <th class="actions"><?= __d('audit_stash', 'Actions') ?></th>
                 </tr>
             </thead>
             <tbody>
@@ -204,15 +204,15 @@
                     <td><?= $this->Audit->formatUser($auditLog->user_id, $auditLog->user_display) ?></td>
                     <td><small><?= $this->Audit->changeSummary($auditLog->changed) ?></small></td>
                     <td class="actions">
-                        <?= $this->Html->link(__('View'), ['action' => 'view', $auditLog->id], ['class' => 'btn btn-sm btn-outline-primary']) ?>
+                        <?= $this->Html->link(__d('audit_stash', 'View'), ['action' => 'view', $auditLog->id], ['class' => 'btn btn-sm btn-outline-primary']) ?>
                         <?php if ($auditLog->primary_key) { ?>
                             <?= $this->Html->link(
-                                __('Timeline'),
+                                __d('audit_stash', 'Timeline'),
                                 ['action' => 'timeline', $auditLog->source, $auditLog->primary_key],
                                 ['class' => 'btn btn-sm btn-outline-secondary']
                             ) ?>
                             <?= $this->Html->link(
-                                __('Related'),
+                                __d('audit_stash', 'Related'),
                                 ['action' => 'relatedChanges', $auditLog->source, $auditLog->primary_key],
                                 ['class' => 'btn btn-sm btn-outline-info']
                             ) ?>

--- a/templates/Admin/AuditLogs/related_changes.php
+++ b/templates/Admin/AuditLogs/related_changes.php
@@ -7,24 +7,24 @@
  */
 ?>
 <div class="auditLogs related-changes content">
-    <h3><?= __('Related Changes') ?></h3>
+    <h3><?= __d('audit_stash', 'Related Changes') ?></h3>
 
     <div class="alert alert-info">
-        <strong><?= __('Record:') ?></strong>
+        <strong><?= __d('audit_stash', 'Record:') ?></strong>
         <code><?= h($source) ?></code> #<?= h($primaryKey) ?>
         <p class="mb-0 mt-2 small">
-            <?= __('Showing all audit logs for this record and related records (via foreign keys).') ?>
+            <?= __d('audit_stash', 'Showing all audit logs for this record and related records (via foreign keys).') ?>
         </p>
     </div>
 
     <div class="mb-3">
         <?= $this->Html->link(
-            __('Back to Index'),
+            __d('audit_stash', 'Back to Index'),
             ['action' => 'index'],
             ['class' => 'btn btn-secondary']
         ) ?>
         <?= $this->Html->link(
-            __('View Timeline'),
+            __d('audit_stash', 'View Timeline'),
             ['action' => 'timeline', $source, $primaryKey],
             ['class' => 'btn btn-outline-primary']
         ) ?>
@@ -32,7 +32,7 @@
 
     <?php if (empty($transactions)) { ?>
         <div class="alert alert-warning">
-            <?= __('No related changes found.') ?>
+            <?= __d('audit_stash', 'No related changes found.') ?>
         </div>
     <?php } else { ?>
         <?php foreach ($transactions as $txId => $transaction) { ?>
@@ -40,7 +40,7 @@
                 <div class="card-header">
                     <div class="d-flex justify-content-between align-items-center">
                         <div>
-                            <strong><?= __('Transaction:') ?></strong>
+                            <strong><?= __d('audit_stash', 'Transaction:') ?></strong>
                             <code class="small"><?= h($transaction['transaction_key']) ?></code>
                         </div>
                         <div class="text-muted small">
@@ -55,11 +55,11 @@
                     <table class="table table-sm table-striped mb-0">
                         <thead>
                             <tr>
-                                <th><?= __('Event') ?></th>
-                                <th><?= __('Source') ?></th>
-                                <th><?= __('Record') ?></th>
-                                <th><?= __('Changes') ?></th>
-                                <th><?= __('Actions') ?></th>
+                                <th><?= __d('audit_stash', 'Event') ?></th>
+                                <th><?= __d('audit_stash', 'Source') ?></th>
+                                <th><?= __d('audit_stash', 'Record') ?></th>
+                                <th><?= __d('audit_stash', 'Changes') ?></th>
+                                <th><?= __d('audit_stash', 'Actions') ?></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -74,20 +74,20 @@
                                     <td>
                                         <code><?= h($log->source) ?></code>
                                         <?php if ($isMainRecord) { ?>
-                                            <span class="badge bg-info"><?= __('Main') ?></span>
+                                            <span class="badge bg-info"><?= __d('audit_stash', 'Main') ?></span>
                                         <?php } ?>
                                     </td>
                                     <td>
                                         <?php if ($log->primary_key) { ?>
                                             <?= $this->Audit->formatRecord($log->source, $log->primary_key, $log->display_value) ?>
                                         <?php } else { ?>
-                                            <span class="badge bg-success"><?= __('New') ?></span>
+                                            <span class="badge bg-success"><?= __d('audit_stash', 'New') ?></span>
                                         <?php } ?>
                                     </td>
                                     <td><small><?= $this->Audit->changeSummary($log->changed) ?></small></td>
                                     <td>
                                         <?= $this->Html->link(
-                                            __('View'),
+                                            __d('audit_stash', 'View'),
                                             ['action' => 'view', $log->id],
                                             ['class' => 'btn btn-sm btn-outline-primary']
                                         ) ?>
@@ -98,7 +98,7 @@
                     </table>
                 </div>
                 <div class="card-footer small text-muted">
-                    <?= __n('{0} record in this transaction', '{0} records in this transaction', count($transaction['logs']), count($transaction['logs'])) ?>
+                    <?= __dn('audit_stash', '{0} record in this transaction', '{0} records in this transaction', count($transaction['logs']), count($transaction['logs'])) ?>
                 </div>
             </div>
         <?php } ?>

--- a/templates/Admin/AuditLogs/restore.php
+++ b/templates/Admin/AuditLogs/restore.php
@@ -8,9 +8,9 @@
 ?>
 <div class="auditLogs restore content">
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h3><?= __('Restore Deleted Record') ?></h3>
+        <h3><?= __d('audit_stash', 'Restore Deleted Record') ?></h3>
         <div>
-            <?= $this->Html->link(__('Back to List'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
+            <?= $this->Html->link(__d('audit_stash', 'Back to List'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
         </div>
     </div>
 
@@ -71,25 +71,25 @@
 
             <?= $this->Form->create(null, ['url' => ['action' => 'restore', $source, $primaryKey]]) ?>
             <div class="alert alert-warning">
-                <strong><?= __('Warning:') ?></strong>
-                <?= __('This will restore the record with the data shown above. If a record with this ID already exists, the restore will fail.') ?>
+                <strong><?= __d('audit_stash', 'Warning:') ?></strong>
+                <?= __d('audit_stash', 'This will restore the record with the data shown above. If a record with this ID already exists, the restore will fail.') ?>
             </div>
             <div class="d-flex justify-content-end gap-2">
-                <?= $this->Html->link(__('Cancel'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
-                <?= $this->Form->button(__('Restore Record'), [
+                <?= $this->Html->link(__d('audit_stash', 'Cancel'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
+                <?= $this->Form->button(__d('audit_stash', 'Restore Record'), [
                     'class' => 'btn btn-primary',
-                    'confirm' => __('Are you sure you want to restore this record?'),
+                    'confirm' => __d('audit_stash', 'Are you sure you want to restore this record?'),
                 ]) ?>
             </div>
             <?= $this->Form->end() ?>
         <?php } else { ?>
             <div class="alert alert-danger">
-                <?= __('No record data available to restore.') ?>
+                <?= __d('audit_stash', 'No record data available to restore.') ?>
             </div>
         <?php } ?>
     <?php } else { ?>
         <div class="alert alert-danger">
-            <?= __('No deletion record found for this record.') ?>
+            <?= __d('audit_stash', 'No deletion record found for this record.') ?>
         </div>
     <?php } ?>
 </div>

--- a/templates/Admin/AuditLogs/revert_preview.php
+++ b/templates/Admin/AuditLogs/revert_preview.php
@@ -10,9 +10,9 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <div class="auditLogs revert content">
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h3><?= __('Revert Preview') ?></h3>
+        <h3><?= __d('audit_stash', 'Revert Preview') ?></h3>
         <div>
-            <?= $this->Html->link(__('Cancel'), ['action' => 'view', $auditLog->id], ['class' => 'btn btn-secondary']) ?>
+            <?= $this->Html->link(__d('audit_stash', 'Cancel'), ['action' => 'view', $auditLog->id], ['class' => 'btn btn-secondary']) ?>
         </div>
     </div>
 
@@ -42,17 +42,17 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 
     <?php if (empty($diff)) { ?>
         <div class="alert alert-info">
-            <?= __('No differences found. Record is already in this state.') ?>
+            <?= __d('audit_stash', 'No differences found. Record is already in this state.') ?>
         </div>
     <?php } else { ?>
         <?= $this->Form->create(null, [
             'url' => ['action' => 'revert', $auditLog->id],
-            'data-confirm-message' => __('Are you sure you want to revert the selected fields?'),
+            'data-confirm-message' => __d('audit_stash', 'Are you sure you want to revert the selected fields?'),
         ]) ?>
 
         <div class="card">
             <div class="card-header">
-                <h5 class="mb-0"><?= __('Fields to Revert') ?></h5>
+                <h5 class="mb-0"><?= __d('audit_stash', 'Fields to Revert') ?></h5>
             </div>
             <div class="card-body">
                 <table class="table table-bordered">
@@ -86,14 +86,14 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
             <div class="card-footer d-flex justify-content-between">
                 <div>
                     <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-select-all">
-                        <?= __('Select All') ?>
+                        <?= __d('audit_stash', 'Select All') ?>
                     </button>
                     <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-select-none">
-                        <?= __('Select None') ?>
+                        <?= __d('audit_stash', 'Select None') ?>
                     </button>
                 </div>
                 <div>
-                    <?= $this->Form->button(__('Revert Selected'), [
+                    <?= $this->Form->button(__d('audit_stash', 'Revert Selected'), [
                         'class' => 'btn btn-primary',
                     ]) ?>
                 </div>

--- a/templates/Admin/AuditLogs/timeline.php
+++ b/templates/Admin/AuditLogs/timeline.php
@@ -11,14 +11,14 @@ use AuditStash\AuditLogType;
 <div class="auditLogs timeline content">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <div>
-            <h3><?= __('Audit Timeline') ?></h3>
+            <h3><?= __d('audit_stash', 'Audit Timeline') ?></h3>
             <p class="text-muted mb-0">
                 <strong>Source:</strong> <code><?= h($source) ?></code> |
                 <strong>Record:</strong> <?= $this->Audit->formatRecord($source, $primaryKey) ?>
             </p>
         </div>
         <div>
-            <?= $this->Html->link(__('Back to List'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
+            <?= $this->Html->link(__d('audit_stash', 'Back to List'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
         </div>
     </div>
 
@@ -80,7 +80,7 @@ use AuditStash\AuditLogType;
                                     </div>
                                     <div>
                                         <?= $this->Html->link(
-                                            __('View Details'),
+                                            __d('audit_stash', 'View Details'),
                                             ['action' => 'view', $auditLog->id],
                                             ['class' => 'btn btn-sm btn-outline-primary']
                                         ) ?>

--- a/templates/Admin/AuditLogs/view.php
+++ b/templates/Admin/AuditLogs/view.php
@@ -8,12 +8,12 @@ use AuditStash\AuditLogType;
 ?>
 <div class="auditLogs view content">
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h3><?= __('Audit Log Details') ?></h3>
+        <h3><?= __d('audit_stash', 'Audit Log Details') ?></h3>
         <div>
-            <?= $this->Html->link(__('Back to List'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
+            <?= $this->Html->link(__d('audit_stash', 'Back to List'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
             <?php if ($auditLog->primary_key) { ?>
                 <?= $this->Html->link(
-                    __('View Timeline'),
+                    __d('audit_stash', 'View Timeline'),
                     ['action' => 'timeline', $auditLog->source, $auditLog->primary_key],
                     ['class' => 'btn btn-primary']
                 ) ?>
@@ -25,20 +25,20 @@ use AuditStash\AuditLogType;
         <div class="col-md-6">
             <div class="card mb-4">
                 <div class="card-header">
-                    <h5 class="mb-0"><?= __('Event Information') ?></h5>
+                    <h5 class="mb-0"><?= __d('audit_stash', 'Event Information') ?></h5>
                 </div>
                 <div class="card-body">
                     <table class="table table-sm">
                         <tr>
-                            <th><?= __('Event Type') ?></th>
+                            <th><?= __d('audit_stash', 'Event Type') ?></th>
                             <td><?= $this->Audit->eventTypeBadge($auditLog->type) ?></td>
                         </tr>
                         <tr>
-                            <th><?= __('Source') ?></th>
+                            <th><?= __d('audit_stash', 'Source') ?></th>
                             <td><code><?= h($auditLog->source) ?></code></td>
                         </tr>
                         <tr>
-                            <th><?= __('Record') ?></th>
+                            <th><?= __d('audit_stash', 'Record') ?></th>
                             <td>
                                 <?php if ($auditLog->primary_key) { ?>
                                     <?= $this->Audit->formatRecord($auditLog->source, $auditLog->primary_key, $auditLog->display_value) ?>
@@ -48,19 +48,19 @@ use AuditStash\AuditLogType;
                             </td>
                         </tr>
                         <tr>
-                            <th><?= __('Parent Source') ?></th>
+                            <th><?= __d('audit_stash', 'Parent Source') ?></th>
                             <td><?= h($auditLog->parent_source) ?: '<em class="text-muted">N/A</em>' ?></td>
                         </tr>
                         <tr>
-                            <th><?= __('Transaction ID') ?></th>
+                            <th><?= __d('audit_stash', 'Transaction ID') ?></th>
                             <td><?= $this->Audit->transactionId($auditLog->transaction_key, true) ?></td>
                         </tr>
                         <tr>
-                            <th><?= __('User') ?></th>
+                            <th><?= __d('audit_stash', 'User') ?></th>
                             <td><?= $this->Audit->formatUser($auditLog->user_id, $auditLog->user_display) ?></td>
                         </tr>
                         <tr>
-                            <th><?= __('Created') ?></th>
+                            <th><?= __d('audit_stash', 'Created') ?></th>
                             <td><?= h($auditLog->created) ?></td>
                         </tr>
                     </table>
@@ -71,7 +71,7 @@ use AuditStash\AuditLogType;
         <div class="col-md-6">
             <div class="card mb-4">
                 <div class="card-header">
-                    <h5 class="mb-0"><?= __('Metadata') ?></h5>
+                    <h5 class="mb-0"><?= __d('audit_stash', 'Metadata') ?></h5>
                 </div>
                 <div class="card-body">
                     <?= $this->Audit->metadata($auditLog->meta) ?>
@@ -83,25 +83,25 @@ use AuditStash\AuditLogType;
     <div class="card">
         <div class="card-header d-flex justify-content-between align-items-center">
             <h5 class="mb-0">
-                <?= __('Changes') ?>
+                <?= __d('audit_stash', 'Changes') ?>
                 <?php if ($auditLog->type === AuditLogType::Create->value) { ?>
-                    <span class="badge bg-info"><?= __('New Record') ?></span>
+                    <span class="badge bg-info"><?= __d('audit_stash', 'New Record') ?></span>
                 <?php } elseif ($auditLog->type === AuditLogType::Delete->value) { ?>
-                    <span class="badge bg-danger"><?= __('Deleted Record') ?></span>
+                    <span class="badge bg-danger"><?= __d('audit_stash', 'Deleted Record') ?></span>
                 <?php } ?>
             </h5>
             <?php if ($auditLog->type === AuditLogType::Update->value) { ?>
             <div class="btn-group btn-group-sm" role="group">
-                <button type="button" class="btn btn-outline-secondary active" id="btn-inline-diff"><?= __('Inline') ?></button>
-                <button type="button" class="btn btn-outline-secondary" id="btn-side-diff"><?= __('Side-by-side') ?></button>
+                <button type="button" class="btn btn-outline-secondary active" id="btn-inline-diff"><?= __d('audit_stash', 'Inline') ?></button>
+                <button type="button" class="btn btn-outline-secondary" id="btn-side-diff"><?= __d('audit_stash', 'Side-by-side') ?></button>
             </div>
             <?php } ?>
         </div>
         <div class="card-body">
             <?php if ($auditLog->type === AuditLogType::Create->value) { ?>
-                <?= $this->Audit->fieldValuesTable($auditLog->changed, __('Created with values:')) ?>
+                <?= $this->Audit->fieldValuesTable($auditLog->changed, __d('audit_stash', 'Created with values:')) ?>
             <?php } elseif ($auditLog->type === AuditLogType::Delete->value) { ?>
-                <?= $this->Audit->fieldValuesTable($auditLog->original, __('Deleted record had these values:')) ?>
+                <?= $this->Audit->fieldValuesTable($auditLog->original, __d('audit_stash', 'Deleted record had these values:')) ?>
             <?php } elseif (in_array($auditLog->type, [AuditLogType::Update->value, AuditLogType::Revert->value], true)) { ?>
                 <div id="inline-diff-view">
                     <?= $this->Audit->diffInline($auditLog->original, $auditLog->changed) ?>
@@ -110,7 +110,7 @@ use AuditStash\AuditLogType;
                     <?= $this->Audit->diff($auditLog->original, $auditLog->changed) ?>
                 </div>
             <?php } else { ?>
-                <?= $this->Audit->fieldValuesTable($auditLog->changed, __('Event payload:')) ?>
+                <?= $this->Audit->fieldValuesTable($auditLog->changed, __d('audit_stash', 'Event payload:')) ?>
             <?php } ?>
         </div>
     </div>

--- a/templates/Admin/AuditStash/coverage.php
+++ b/templates/Admin/AuditStash/coverage.php
@@ -52,9 +52,10 @@ $chip = function (string $key, string $label, int $count) use ($filter, $include
 <div class="auditlogs coverage">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <div>
-            <h3 class="mb-0"><?= __('Audit Coverage') ?></h3>
+            <h3 class="mb-0"><?= __d('audit_stash', 'Audit Coverage') ?></h3>
             <p class="text-muted mb-0 small">
-                <?= __(
+                <?= __d(
+                    'audit_stash',
                     '{0} of {1} discoverable tables have AuditLog behavior attached.',
                     '<strong>' . h((string)$summary['tracked']) . '</strong>',
                     '<strong>' . h((string)$summary['total']) . '</strong>',
@@ -62,17 +63,17 @@ $chip = function (string $key, string $label, int $count) use ($filter, $include
             </p>
         </div>
         <div>
-            <?= $this->Html->link(__('← Dashboard'), ['controller' => 'AuditStash', 'action' => 'index'], ['class' => 'btn btn-outline-secondary']) ?>
+            <?= $this->Html->link(__d('audit_stash', '← Dashboard'), ['controller' => 'AuditStash', 'action' => 'index'], ['class' => 'btn btn-outline-secondary']) ?>
         </div>
     </div>
 
     <div class="d-flex flex-wrap gap-2 mb-3 align-items-center">
         <?php
         $allCount = $summary['tracked'] + $summary['missing'] + $summary['empirical'];
-        echo $chip('all', __('All'), $allCount);
-        echo $chip('tracked', __('Tracked'), $summary['tracked']);
-        echo $chip('missing', __('Missing'), $summary['missing']);
-        echo $chip('empirical', __('Empirical'), $summary['empirical']);
+        echo $chip('all', __d('audit_stash', 'All'), $allCount);
+        echo $chip('tracked', __d('audit_stash', 'Tracked'), $summary['tracked']);
+        echo $chip('missing', __d('audit_stash', 'Missing'), $summary['missing']);
+        echo $chip('empirical', __d('audit_stash', 'Empirical'), $summary['empirical']);
         ?>
 
         <div class="form-check form-switch ms-3">
@@ -89,7 +90,7 @@ $chip = function (string $key, string $label, int $count) use ($filter, $include
             <input class="form-check-input" type="checkbox" role="switch"
                    id="includeInternal" <?= $includeInternal ? 'checked' : '' ?>
                    onclick="window.location='<?= h($toggleUrl) ?>'">
-            <label class="form-check-label small" for="includeInternal"><?= __('Include internal tables') ?></label>
+            <label class="form-check-label small" for="includeInternal"><?= __d('audit_stash', 'Include internal tables') ?></label>
         </div>
     </div>
 
@@ -98,11 +99,11 @@ $chip = function (string $key, string $label, int $count) use ($filter, $include
             <table class="table table-sm mb-0">
                 <thead>
                     <tr>
-                        <th><?= __('Status') ?></th>
-                        <th><?= __('Alias') ?></th>
-                        <th><?= __('Plugin') ?></th>
-                        <th><?= __('Class') ?></th>
-                        <th class="text-end"><?= __('Events (30d)') ?></th>
+                        <th><?= __d('audit_stash', 'Status') ?></th>
+                        <th><?= __d('audit_stash', 'Alias') ?></th>
+                        <th><?= __d('audit_stash', 'Plugin') ?></th>
+                        <th><?= __d('audit_stash', 'Class') ?></th>
+                        <th class="text-end"><?= __d('audit_stash', 'Events (30d)') ?></th>
                         <th></th>
                     </tr>
                 </thead>
@@ -110,7 +111,7 @@ $chip = function (string $key, string $label, int $count) use ($filter, $include
                     <?php if (!$rows) { ?>
                         <tr>
                             <td colspan="6" class="text-center text-muted py-4">
-                                <?= __('No tables match this filter.') ?>
+                                <?= __d('audit_stash', 'No tables match this filter.') ?>
                             </td>
                         </tr>
                     <?php } ?>
@@ -121,7 +122,7 @@ $chip = function (string $key, string $label, int $count) use ($filter, $include
                                 <code><?= h($row['alias']) ?></code>
                                 <?php if (!empty($row['source']) && $row['source'] !== $row['alias']) { ?>
                                     <div class="small text-muted">
-                                        <?= __('audit source: {0}', '<code>' . h($row['source']) . '</code>') ?>
+                                        <?= __d('audit_stash', 'audit source: {0}', '<code>' . h($row['source']) . '</code>') ?>
                                     </div>
                                 <?php } ?>
                             </td>
@@ -130,7 +131,7 @@ $chip = function (string $key, string $label, int $count) use ($filter, $include
                                 <?php if ($row['class']) { ?>
                                     <code class="small text-muted"><?= h($row['class']) ?></code>
                                 <?php } else { ?>
-                                    <span class="text-muted small"><?= __('No class found') ?></span>
+                                    <span class="text-muted small"><?= __d('audit_stash', 'No class found') ?></span>
                                 <?php } ?>
                                 <?php if ($row['instantiation_error']) { ?>
                                     <div class="text-danger small">⚠️ <?= h($row['instantiation_error']) ?></div>
@@ -140,7 +141,7 @@ $chip = function (string $key, string $label, int $count) use ($filter, $include
                             <td class="text-end">
                                 <?php if ($row['events_30d'] > 0) { ?>
                                     <?= $this->Html->link(
-                                        __('View activity'),
+                                        __d('audit_stash', 'View activity'),
                                         ['controller' => 'AuditLogs', 'action' => 'index', '?' => ['source' => $row['source'] ?? $row['alias']]],
                                         ['class' => 'btn btn-sm btn-outline-primary'],
                                     ) ?>
@@ -154,19 +155,19 @@ $chip = function (string $key, string $label, int $count) use ($filter, $include
     </div>
 
     <details class="mt-3 small text-muted">
-        <summary><?= __('Status legend') ?></summary>
+        <summary><?= __d('audit_stash', 'Status legend') ?></summary>
         <dl class="row mb-0 mt-2">
-            <dt class="col-sm-2"><?= __('Tracked') ?></dt>
-            <dd class="col-sm-10"><?= __('Class exists, AuditLog behavior attached.') ?></dd>
+            <dt class="col-sm-2"><?= __d('audit_stash', 'Tracked') ?></dt>
+            <dd class="col-sm-10"><?= __d('audit_stash', 'Class exists, AuditLog behavior attached.') ?></dd>
 
-            <dt class="col-sm-2"><?= __('Missing') ?></dt>
-            <dd class="col-sm-10"><?= __('Class exists, behavior NOT attached — coverage gap.') ?></dd>
+            <dt class="col-sm-2"><?= __d('audit_stash', 'Missing') ?></dt>
+            <dd class="col-sm-10"><?= __d('audit_stash', 'Class exists, behavior NOT attached — coverage gap.') ?></dd>
 
-            <dt class="col-sm-2"><?= __('Empirical') ?></dt>
-            <dd class="col-sm-10"><?= __("Events recorded for a source we couldn't map to a class — custom event source, renamed table, or plugin uninstalled.") ?></dd>
+            <dt class="col-sm-2"><?= __d('audit_stash', 'Empirical') ?></dt>
+            <dd class="col-sm-10"><?= __d('audit_stash', "Events recorded for a source we couldn't map to a class — custom event source, renamed table, or plugin uninstalled.") ?></dd>
 
-            <dt class="col-sm-2"><?= __('Internal') ?></dt>
-            <dd class="col-sm-10"><?= __('Hidden by deny-list — toggle above to include.') ?></dd>
+            <dt class="col-sm-2"><?= __d('audit_stash', 'Internal') ?></dt>
+            <dd class="col-sm-10"><?= __d('audit_stash', 'Hidden by deny-list — toggle above to include.') ?></dd>
         </dl>
     </details>
 </div>

--- a/templates/Admin/AuditStash/index.php
+++ b/templates/Admin/AuditStash/index.php
@@ -61,12 +61,12 @@ $usersDelta = $delta($kpis['active_users_today'], $kpis['active_users_yesterday'
 <div class="auditlogs dashboard">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <div>
-            <h3 class="mb-0"><?= __('Audit Dashboard') ?></h3>
-            <p class="text-muted mb-0 small"><?= __('Activity, coverage, and integrity at a glance.') ?></p>
+            <h3 class="mb-0"><?= __d('audit_stash', 'Audit Dashboard') ?></h3>
+            <p class="text-muted mb-0 small"><?= __d('audit_stash', 'Activity, coverage, and integrity at a glance.') ?></p>
         </div>
         <div>
             <?= $this->Html->link(
-                __('Browse all logs') . ' →',
+                __d('audit_stash', 'Browse all logs') . ' →',
                 ['controller' => 'AuditLogs', 'action' => 'index'],
                 ['class' => 'btn btn-primary'],
             ) ?>
@@ -77,11 +77,11 @@ $usersDelta = $delta($kpis['active_users_today'], $kpis['active_users_yesterday'
         <div class="col">
             <div class="card h-100">
                 <div class="card-body">
-                    <div class="text-muted small text-uppercase"><?= __('Events today') ?></div>
+                    <div class="text-muted small text-uppercase"><?= __d('audit_stash', 'Events today') ?></div>
                     <div class="d-flex align-items-baseline gap-2">
                         <div class="display-6 fw-bold"><?= h(number_format($kpis['events_today'])) ?></div>
                         <div class="<?= h($eventsDelta['class']) ?> small">
-                            <?= h($eventsDelta['label']) ?> <?= __('vs yesterday') ?>
+                            <?= h($eventsDelta['label']) ?> <?= __d('audit_stash', 'vs yesterday') ?>
                         </div>
                     </div>
                 </div>
@@ -90,11 +90,11 @@ $usersDelta = $delta($kpis['active_users_today'], $kpis['active_users_yesterday'
         <div class="col">
             <div class="card h-100">
                 <div class="card-body">
-                    <div class="text-muted small text-uppercase"><?= __('Active users today') ?></div>
+                    <div class="text-muted small text-uppercase"><?= __d('audit_stash', 'Active users today') ?></div>
                     <div class="d-flex align-items-baseline gap-2">
                         <div class="display-6 fw-bold"><?= h(number_format($kpis['active_users_today'])) ?></div>
                         <div class="<?= h($usersDelta['class']) ?> small">
-                            <?= h($usersDelta['label']) ?> <?= __('vs yesterday') ?>
+                            <?= h($usersDelta['label']) ?> <?= __d('audit_stash', 'vs yesterday') ?>
                         </div>
                     </div>
                 </div>
@@ -103,9 +103,9 @@ $usersDelta = $delta($kpis['active_users_today'], $kpis['active_users_yesterday'
         <div class="col">
             <div class="card h-100">
                 <div class="card-body">
-                    <div class="text-muted small text-uppercase"><?= __('Active sources (7d)') ?></div>
+                    <div class="text-muted small text-uppercase"><?= __d('audit_stash', 'Active sources (7d)') ?></div>
                     <div class="display-6 fw-bold"><?= h(number_format($kpis['sources_7d'])) ?></div>
-                    <div class="small text-muted"><?= __('distinct tables/sources with activity') ?></div>
+                    <div class="small text-muted"><?= __d('audit_stash', 'distinct tables/sources with activity') ?></div>
                 </div>
             </div>
         </div>
@@ -117,10 +117,10 @@ $usersDelta = $delta($kpis['active_users_today'], $kpis['active_users_yesterday'
                     . '<div class="display-6 fw-bold">%s / %s</div>'
                     . '<div class="small text-muted">%s</div>'
                     . '</div></div>',
-                    h(__('Coverage')),
+                    h(__d('audit_stash', 'Coverage')),
                     h(number_format($coverage['tracked'])),
                     h(number_format($coverage['total'])),
-                    h(__('tables with AuditLog behavior')),
+                    h(__d('audit_stash', 'tables with AuditLog behavior')),
                 ),
                 ['controller' => 'AuditStash', 'action' => 'coverage'],
                 ['escapeTitle' => false, 'class' => 'text-decoration-none text-reset'],
@@ -130,7 +130,7 @@ $usersDelta = $delta($kpis['active_users_today'], $kpis['active_users_yesterday'
 
     <div class="card mb-4">
         <div class="card-header d-flex justify-content-between align-items-center">
-            <h5 class="mb-0"><?= __('Events over time (last 30 days)') ?></h5>
+            <h5 class="mb-0"><?= __d('audit_stash', 'Events over time (last 30 days)') ?></h5>
             <div class="small text-muted d-flex gap-3">
                 <?php foreach ($typeColor as $type => $color) { ?>
                     <span class="d-inline-flex align-items-center gap-1">
@@ -140,7 +140,7 @@ $usersDelta = $delta($kpis['active_users_today'], $kpis['active_users_yesterday'
                 <?php } ?>
                 <span class="d-inline-flex align-items-center gap-1">
                     <span style="display: inline-block; width: 10px; height: 10px; background: #6c757d; border-radius: 2px;"></span>
-                    <?= __('Other') ?>
+                    <?= __d('audit_stash', 'Other') ?>
                 </span>
             </div>
         </div>
@@ -176,10 +176,10 @@ $usersDelta = $delta($kpis['active_users_today'], $kpis['active_users_yesterday'
     <div class="row g-3 mb-4">
         <div class="col-md-6">
             <div class="card h-100">
-                <div class="card-header"><h5 class="mb-0"><?= __('Top sources (7 days)') ?></h5></div>
+                <div class="card-header"><h5 class="mb-0"><?= __d('audit_stash', 'Top sources (7 days)') ?></h5></div>
                 <div class="card-body">
                     <?php if (!$topSources) { ?>
-                        <p class="text-muted mb-0"><?= __('No activity yet.') ?></p>
+                        <p class="text-muted mb-0"><?= __d('audit_stash', 'No activity yet.') ?></p>
                     <?php } else { ?>
                         <?php foreach ($topSources as $row) {
                             $widthPct = ($row['count'] / $topSourceMax) * 100;
@@ -204,14 +204,14 @@ $usersDelta = $delta($kpis['active_users_today'], $kpis['active_users_yesterday'
         </div>
         <div class="col-md-6">
             <div class="card h-100">
-                <div class="card-header"><h5 class="mb-0"><?= __('Top users (7 days)') ?></h5></div>
+                <div class="card-header"><h5 class="mb-0"><?= __d('audit_stash', 'Top users (7 days)') ?></h5></div>
                 <div class="card-body">
                     <?php if (!$topUsers) { ?>
-                        <p class="text-muted mb-0"><?= __('No user-attributed activity yet.') ?></p>
+                        <p class="text-muted mb-0"><?= __d('audit_stash', 'No user-attributed activity yet.') ?></p>
                     <?php } else { ?>
                         <?php foreach ($topUsers as $row) {
                             $widthPct = ($row['count'] / $topUserMax) * 100;
-                            $label = $row['user_display'] ?: ($row['user_id'] ?: __('(anonymous)'));
+                            $label = $row['user_display'] ?: ($row['user_id'] ?: __d('audit_stash', '(anonymous)'));
                             ?>
                             <div class="mb-2">
                                 <div class="d-flex justify-content-between small mb-1">
@@ -235,9 +235,9 @@ $usersDelta = $delta($kpis['active_users_today'], $kpis['active_users_yesterday'
 
     <div class="card">
         <div class="card-header d-flex justify-content-between align-items-center">
-            <h5 class="mb-0"><?= __('Recent activity') ?></h5>
+            <h5 class="mb-0"><?= __d('audit_stash', 'Recent activity') ?></h5>
             <?= $this->Html->link(
-                __('Open full log') . ' →',
+                __d('audit_stash', 'Open full log') . ' →',
                 ['controller' => 'AuditLogs', 'action' => 'index'],
                 ['class' => 'btn btn-sm btn-outline-secondary'],
             ) ?>
@@ -246,11 +246,11 @@ $usersDelta = $delta($kpis['active_users_today'], $kpis['active_users_yesterday'
             <table class="table table-sm mb-0">
                 <thead>
                     <tr>
-                        <th><?= __('When') ?></th>
-                        <th><?= __('Type') ?></th>
-                        <th><?= __('Source') ?></th>
-                        <th><?= __('Record') ?></th>
-                        <th><?= __('User') ?></th>
+                        <th><?= __d('audit_stash', 'When') ?></th>
+                        <th><?= __d('audit_stash', 'Type') ?></th>
+                        <th><?= __d('audit_stash', 'Source') ?></th>
+                        <th><?= __d('audit_stash', 'Record') ?></th>
+                        <th><?= __d('audit_stash', 'User') ?></th>
                         <th></th>
                     </tr>
                 </thead>
@@ -270,7 +270,7 @@ $usersDelta = $delta($kpis['active_users_today'], $kpis['active_users_yesterday'
                             <td class="small"><?= $this->Audit->formatUser($log->user_id, $log->user_display) ?></td>
                             <td class="text-end">
                                 <?= $this->Html->link(
-                                    __('View'),
+                                    __d('audit_stash', 'View'),
                                     ['controller' => 'AuditLogs', 'action' => 'view', $log->id],
                                     ['class' => 'btn btn-sm btn-outline-primary'],
                                 ) ?>

--- a/templates/element/AuditStash/mobile_nav.php
+++ b/templates/element/AuditStash/mobile_nav.php
@@ -35,61 +35,61 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
     <div class="offcanvas-body">
         <!-- Navigation -->
         <div class="mb-4">
-            <div class="text-white-50 small text-uppercase mb-2"><?= __('Navigation') ?></div>
+            <div class="text-white-50 small text-uppercase mb-2"><?= __d('audit_stash', 'Navigation') ?></div>
             <nav class="nav flex-column">
                 <a class="nav-link text-white-50 <?= $isActive('AuditStash', ['index']) ? 'text-white fw-bold' : '' ?>"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditStash', 'action' => 'index']) ?>">
                     <i class="fas fa-gauge me-2"></i>
-                    <?= __('Dashboard') ?>
+                    <?= __d('audit_stash', 'Dashboard') ?>
                 </a>
                 <a class="nav-link text-white-50 <?= $isActive('AuditLogs', ['index']) ? 'text-white fw-bold' : '' ?>"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'index']) ?>">
                     <i class="fas fa-list me-2"></i>
-                    <?= __('Audit Logs') ?>
+                    <?= __d('audit_stash', 'Audit Logs') ?>
                 </a>
                 <a class="nav-link text-white-50 <?= $isActive('AuditLogs', ['bulkChanges']) ? 'text-white fw-bold' : '' ?>"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'bulkChanges']) ?>">
                     <i class="fas fa-layer-group me-2"></i>
-                    <?= __('Bulk Changes') ?>
+                    <?= __d('audit_stash', 'Bulk Changes') ?>
                 </a>
                 <a class="nav-link text-white-50 <?= $isActive('AuditStash', ['coverage']) ? 'text-white fw-bold' : '' ?>"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditStash', 'action' => 'coverage']) ?>">
                     <i class="fas fa-shield-halved me-2"></i>
-                    <?= __('Coverage') ?>
+                    <?= __d('audit_stash', 'Coverage') ?>
                 </a>
             </nav>
         </div>
 
         <!-- Quick Filters -->
         <div class="mb-4">
-            <div class="text-white-50 small text-uppercase mb-2"><?= __('Quick Filters') ?></div>
+            <div class="text-white-50 small text-uppercase mb-2"><?= __d('audit_stash', 'Quick Filters') ?></div>
             <nav class="nav flex-column">
                 <a class="nav-link text-white-50"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'index', '?' => ['type' => 'create']]) ?>">
                     <i class="fas fa-plus-circle me-2"></i>
-                    <?= __('Creates') ?>
+                    <?= __d('audit_stash', 'Creates') ?>
                 </a>
                 <a class="nav-link text-white-50"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'index', '?' => ['type' => 'update']]) ?>">
                     <i class="fas fa-edit me-2"></i>
-                    <?= __('Updates') ?>
+                    <?= __d('audit_stash', 'Updates') ?>
                 </a>
                 <a class="nav-link text-white-50"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'index', '?' => ['type' => 'delete']]) ?>">
                     <i class="fas fa-trash me-2"></i>
-                    <?= __('Deletes') ?>
+                    <?= __d('audit_stash', 'Deletes') ?>
                 </a>
             </nav>
         </div>
 
         <!-- Export -->
         <div class="mb-4">
-            <div class="text-white-50 small text-uppercase mb-2"><?= __('Export') ?></div>
+            <div class="text-white-50 small text-uppercase mb-2"><?= __d('audit_stash', 'Export') ?></div>
             <nav class="nav flex-column">
                 <a class="nav-link text-white-50"
                    href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'export']) ?>">
                     <i class="fas fa-file-export me-2"></i>
-                    <?= __('Export…') ?>
+                    <?= __d('audit_stash', 'Export…') ?>
                 </a>
             </nav>
         </div>

--- a/templates/element/AuditStash/sidebar.php
+++ b/templates/element/AuditStash/sidebar.php
@@ -24,76 +24,76 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
 <aside class="audit-sidebar d-none d-lg-block">
     <!-- Navigation -->
     <div class="nav-section">
-        <div class="nav-section-title"><?= __('Navigation') ?></div>
+        <div class="nav-section-title"><?= __d('audit_stash', 'Navigation') ?></div>
         <nav class="nav flex-column">
             <a class="nav-link <?= $isActive('AuditStash', ['index']) ?>"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditStash', 'action' => 'index']) ?>">
                 <?= $this->element('AuditStash.icon', ['name' => 'gauge', 'fallback' => 'fas fa-gauge']) ?>
-                <?= __('Dashboard') ?>
+                <?= __d('audit_stash', 'Dashboard') ?>
             </a>
             <a class="nav-link <?= $isActive('AuditLogs', ['index']) ?>"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'index']) ?>">
                 <?= $this->element('AuditStash.icon', ['name' => 'list', 'fallback' => 'fas fa-list']) ?>
-                <?= __('Audit Logs') ?>
+                <?= __d('audit_stash', 'Audit Logs') ?>
             </a>
             <a class="nav-link <?= $isActive('AuditLogs', ['bulkChanges']) ?>"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'bulkChanges']) ?>">
                 <?= $this->element('AuditStash.icon', ['name' => 'layer-group', 'fallback' => 'fas fa-layer-group']) ?>
-                <?= __('Bulk Changes') ?>
+                <?= __d('audit_stash', 'Bulk Changes') ?>
             </a>
             <a class="nav-link <?= $isActive('AuditStash', ['coverage']) ?>"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditStash', 'action' => 'coverage']) ?>">
                 <?= $this->element('AuditStash.icon', ['name' => 'shield-halved', 'fallback' => 'fas fa-shield-halved']) ?>
-                <?= __('Coverage') ?>
+                <?= __d('audit_stash', 'Coverage') ?>
             </a>
         </nav>
     </div>
 
     <!-- Quick Filters -->
     <div class="nav-section">
-        <div class="nav-section-title"><?= __('Quick Filters') ?></div>
+        <div class="nav-section-title"><?= __d('audit_stash', 'Quick Filters') ?></div>
         <nav class="nav flex-column">
             <a class="nav-link"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'index', '?' => ['type' => 'create']]) ?>">
                 <?= $this->element('AuditStash.icon', ['name' => 'plus-circle', 'fallback' => 'fas fa-plus-circle']) ?>
-                <?= __('Creates') ?>
+                <?= __d('audit_stash', 'Creates') ?>
             </a>
             <a class="nav-link"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'index', '?' => ['type' => 'update']]) ?>">
                 <?= $this->element('AuditStash.icon', ['name' => 'edit', 'fallback' => 'fas fa-edit']) ?>
-                <?= __('Updates') ?>
+                <?= __d('audit_stash', 'Updates') ?>
             </a>
             <a class="nav-link"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'index', '?' => ['type' => 'delete']]) ?>">
                 <?= $this->element('AuditStash.icon', ['name' => 'trash', 'fallback' => 'fas fa-trash']) ?>
-                <?= __('Deletes') ?>
+                <?= __d('audit_stash', 'Deletes') ?>
             </a>
         </nav>
     </div>
 
     <!-- Export -->
     <div class="nav-section">
-        <div class="nav-section-title"><?= __('Export') ?></div>
+        <div class="nav-section-title"><?= __d('audit_stash', 'Export') ?></div>
         <nav class="nav flex-column">
             <a class="nav-link"
                href="<?= $this->Url->build(['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditLogs', 'action' => 'export']) ?>">
                 <?= $this->element('AuditStash.icon', ['name' => 'file-export', 'fallback' => 'fas fa-file-export']) ?>
-                <?= __('Export…') ?>
+                <?= __d('audit_stash', 'Export…') ?>
             </a>
         </nav>
     </div>
 
     <?php if (\Cake\Core\Configure::read('debug')) { ?>
     <div class="nav-section">
-        <div class="nav-section-title text-warning"><?= __('Debug') ?></div>
+        <div class="nav-section-title text-warning"><?= __d('audit_stash', 'Debug') ?></div>
         <nav class="nav flex-column">
             <?= $this->Form->postLink(
-                $this->element('AuditStash.icon', ['name' => 'eraser', 'fallback' => 'fas fa-eraser']) . ' ' . __('Reset (truncate)'),
+                $this->element('AuditStash.icon', ['name' => 'eraser', 'fallback' => 'fas fa-eraser']) . ' ' . __d('audit_stash', 'Reset (truncate)'),
                 ['plugin' => $plugin, 'prefix' => $prefix, 'controller' => 'AuditStash', 'action' => 'reset'],
                 [
                     'class' => 'nav-link text-danger',
                     'escapeTitle' => false,
-                    'confirm' => __('This wipes ALL audit log rows. Continue?'),
+                    'confirm' => __d('audit_stash', 'This wipes ALL audit log rows. Continue?'),
                     'block' => true,
                 ],
             ) ?>

--- a/templates/element/pagination.php
+++ b/templates/element/pagination.php
@@ -23,7 +23,7 @@ $this->Paginator->setTemplates([
 	'current' => '<li class="page-item active"><span class="page-link">{{text}}</span></li>',
 ]);
 ?>
-<nav class="mt-3" aria-label="<?= __('Page navigation') ?>">
+<nav class="mt-3" aria-label="<?= __d('audit_stash', 'Page navigation') ?>">
 	<ul class="pagination justify-content-center mb-2">
 		<?= $this->Paginator->first('<i class="fas fa-angle-double-left"></i>', ['escape' => false]) ?>
 		<?= $this->Paginator->prev('<i class="fas fa-angle-left"></i>', ['escape' => false]) ?>
@@ -32,6 +32,6 @@ $this->Paginator->setTemplates([
 		<?= $this->Paginator->last('<i class="fas fa-angle-double-right"></i>', ['escape' => false]) ?>
 	</ul>
 	<p class="text-center text-muted small mb-0">
-		<?= $this->Paginator->counter(__('Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?>
+		<?= $this->Paginator->counter(__d('audit_stash', 'Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?>
 	</p>
 </nav>

--- a/templates/element/yes_no.php
+++ b/templates/element/yes_no.php
@@ -13,8 +13,8 @@
 $value = $value ?? false;
 $options = $options ?? [];
 
-$yesLabel = $options['yesLabel'] ?? __('Yes');
-$noLabel = $options['noLabel'] ?? __('No');
+$yesLabel = $options['yesLabel'] ?? __d('audit_stash', 'Yes');
+$noLabel = $options['noLabel'] ?? __d('audit_stash', 'No');
 
 // Try Templating plugin's helper
 if ($this->helpers()->has('Templating')) {


### PR DESCRIPTION
## Summary

- Convert 203 `__()` and 1 `__n()` call across `src/` and `templates/` to `__d('audit_stash', ...)` / `__dn('audit_stash', ...)`. The single pre-existing `__d('audit_stash', ...)` call in the layout already pointed at the right domain — the rest of the plugin now matches.
- Add `resources/locales/audit_stash.pot` (168 unique msgids) generated via `bin/cake i18n extract` so language packs can be derived from a stable POT.

## Why

User-facing strings were landing in the host app's `default` domain. Anyone translating the host app would have ended up translating this plugin's UI under their own domain — and shipping a translated language pack with the plugin was effectively impossible. Routing everything through the `audit_stash` domain fixes both.

## Verification (local)

- phpunit: 399 / 399
- phpstan: no errors
- phpcs: clean