### PR TITLE
Fix unreadable current-page number in pagination

### DIFF
--- a/templates/layout/audit_stash.php
+++ b/templates/layout/audit_stash.php
@@ -233,6 +233,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
         .pagination .page-item.active .page-link {
             background-color: var(--audit-primary);
             border-color: var(--audit-primary);
+            color: #fff;
         }
 
         /* Buttons */


### PR DESCRIPTION
The general `.pagination .page-link` rule sets `color: var(--audit-primary)`. The active rule then sets `background-color: var(--audit-primary)` without overriding the text color, leaving the current-page number rendered as purple text on a purple background.

Override `color: #fff` on `.pagination .page-item.active .page-link`.