### PR TITLE
Add configurable Back-to-App link to admin header

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -19,6 +19,28 @@ return [
         'routePath' => '/audit-stash',
 
         /**
+         * Back-to-App link in the admin header
+         *
+         * Optional. When set, an outline "Back to App" button appears in the
+         * admin header between the brand and the cross-link/clock — gives
+         * admins a one-click way out of the plugin-isolated layout back to
+         * the host application's admin home (or wherever you point it).
+         *
+         * Accepts anything `\Cake\Routing\Router::url()` accepts: a Cake URL
+         * array, a path string, or a full URL. Use `'plugin' => false` to
+         * anchor the URL builder to the host app rather than this plugin.
+         *
+         * Defaults to null (button hidden).
+         */
+        // 'adminBackUrl' => ['plugin' => false, 'prefix' => 'Admin', 'controller' => 'Overview', 'action' => 'index'],
+
+        /**
+         * Optional override for the Back-to-App button's text. Defaults to
+         * "Back to App" (translated through the `audit_stash` domain).
+         */
+        // 'adminBackLabel' => 'Back to admin',
+
+        /**
          * Admin Layout Configuration
          *
          * Controls which layout is used for the admin interface:

--- a/docs/features/viewer.md
+++ b/docs/features/viewer.md
@@ -354,6 +354,32 @@ render inside:
 ],
 ```
 
+## Back-to-App link
+
+`AuditStash.adminBackUrl` adds an outline "Back to App" button in the admin
+header, between the brand and the cross-link/clock. Useful when you keep the
+plugin's self-contained layout and need a one-click escape back to the host
+app's admin home.
+
+Accepts anything `Router::url()` accepts: a Cake URL array, a path string, or
+a full URL. Use `'plugin' => false` to anchor the URL builder to the host app
+rather than the plugin's namespace.
+
+```php
+'AuditStash' => [
+    'adminBackUrl' => [
+        'plugin' => false,
+        'prefix' => 'Admin',
+        'controller' => 'Overview',
+        'action' => 'index',
+    ],
+    // optional, defaults to "Back to App"
+    'adminBackLabel' => __('Back to admin'),
+],
+```
+
+When unset (the default), the button is hidden — the header looks unchanged.
+
 ## Required: `AuditStash.adminAccess`
 
 The plugin refuses to serve any admin action unless `AuditStash.adminAccess` is explicitly set to a `Closure` — same posture as `cakephp-queue` / `cakephp-databaselog`, because audit logs commonly contain sensitive who-did-what records (PII, IP addresses, before/after field values) and a forgotten host-side guard would expose more than a typical admin page.

--- a/templates/layout/audit_stash.php
+++ b/templates/layout/audit_stash.php
@@ -348,13 +348,24 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
             <i class="fas fa-clipboard-list"></i>
             AuditStash Admin
         </a>
+        <?php
+        $adminBackUrl = \Cake\Core\Configure::read('AuditStash.adminBackUrl');
+        $hasAdminBack = $adminBackUrl !== null && $adminBackUrl !== '';
+        $adminBackLabel = (string)\Cake\Core\Configure::read('AuditStash.adminBackLabel', __d('audit_stash', 'Back to App'));
+        ?>
+        <?php if ($hasAdminBack) { ?>
+        <a class="btn btn-outline-light btn-sm ms-auto" href="<?= $this->Url->build($adminBackUrl) ?>">
+            <i class="fas fa-arrow-left me-1"></i>
+            <?= h($adminBackLabel) ?>
+        </a>
+        <?php } ?>
         <?php if ($hasBouncerPlugin) { ?>
-        <a class="btn btn-outline-light btn-sm ms-auto" href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index']) ?>">
+        <a class="btn btn-outline-light btn-sm <?= $hasAdminBack ? 'ms-2' : 'ms-auto' ?>" href="<?= $this->Url->build(['plugin' => 'Bouncer', 'prefix' => $prefix, 'controller' => 'Bouncer', 'action' => 'index']) ?>">
             <i class="fas fa-shield-alt me-1"></i>
             Bouncer
         </a>
         <?php } ?>
-        <span class="text-light small <?= $hasBouncerPlugin ? 'ms-3' : 'ms-auto' ?>" title="<?= __d('audit_stash', 'Server Time') ?>">
+        <span class="text-light small <?= ($hasAdminBack || $hasBouncerPlugin) ? 'ms-3' : 'ms-auto' ?>" title="<?= __d('audit_stash', 'Server Time') ?>">
             <i class="far fa-clock me-1"></i>
             <?= date('Y-m-d H:i:s') ?>
         </span>


### PR DESCRIPTION
Configurable Back-to-App link in the admin header. Reads `<Plugin>.adminBackUrl` (any URL — string, array, anything `$this->Url->build()` accepts). Optional `<Plugin>.adminBackLabel` overrides the default "Back to App" text. Hidden by default — set the URL to opt in.

Same shape across cakephp-audit-stash, cakephp-bouncer, and cakephp-databaselog so hosts loading multiple plugins set them with consistent config.