### PR TITLE
Fix related-changes finder for irregular plural and -ies source names

### DIFF
--- a/src/Model/Table/AuditLogsTable.php
+++ b/src/Model/Table/AuditLogsTable.php
@@ -7,6 +7,7 @@ namespace AuditStash\Model\Table;
 use AuditStash\Database\JsonQueryHelper;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
+use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
 
 /**
@@ -416,19 +417,20 @@ class AuditLogsTable extends Table
     }
 
     /**
-     * Build a foreign key name from a table/source name
+     * Build a foreign key name from a table/source name.
      *
-     * @param string $source The table/source name (e.g., "Articles", "UserProfiles")
+     * Uses Cake's Inflector for both snake_case conversion and singularization
+     * so irregular plurals (people → person_id), already-singular words
+     * (news → news_id), and `-ies` plurals (categories → category_id) all
+     * resolve correctly. The previous homegrown `rtrim($x, 's')` produced
+     * `peopl_id`, `new_id`, and `categorie_id` respectively.
      *
-     * @return string The foreign key name (e.g., "article_id", "user_profile_id")
+     * @param string $source The table/source name (e.g., "Articles", "UserProfiles", "Categories", "People")
+     *
+     * @return string The foreign key name (e.g., "article_id", "user_profile_id", "category_id", "person_id")
      */
     protected function buildForeignKeyName(string $source): string
     {
-        // Convert CamelCase to snake_case and singularize
-        $underscored = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $source) ?? $source);
-        // Simple singularize - remove trailing 's' if present
-        $singular = rtrim($underscored, 's');
-
-        return $singular . '_id';
+        return Inflector::singularize(Inflector::underscore($source)) . '_id';
     }
 }

--- a/src/Model/Table/AuditLogsTable.php
+++ b/src/Model/Table/AuditLogsTable.php
@@ -13,6 +13,7 @@ use Cake\Validation\Validator;
 /**
  * AuditLogs Model
  *
+ * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  * @method \AuditStash\Model\Entity\AuditLog newEmptyEntity()
  * @method \AuditStash\Model\Entity\AuditLog newEntity(array $data, array $options = [])
  * @method array<\AuditStash\Model\Entity\AuditLog> newEntities(array $data, array $options = [])
@@ -27,7 +28,6 @@ use Cake\Validation\Validator;
  * @method iterable<\AuditStash\Model\Entity\AuditLog>|\Cake\Datasource\ResultSetInterface<\AuditStash\Model\Entity\AuditLog>|false deleteMany(iterable $entities, array $options = [])
  * @method iterable<\AuditStash\Model\Entity\AuditLog>|\Cake\Datasource\ResultSetInterface<\AuditStash\Model\Entity\AuditLog> deleteManyOrFail(iterable $entities, array $options = [])
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @extends \Cake\ORM\Table<array{Timestamp: \Cake\ORM\Behavior\TimestampBehavior}>
  */
 class AuditLogsTable extends Table
 {

--- a/tests/TestCase/Model/Table/AuditLogsTableTest.php
+++ b/tests/TestCase/Model/Table/AuditLogsTableTest.php
@@ -482,6 +482,111 @@ class AuditLogsTableTest extends TestCase
     }
 
     /**
+     * Regression: `Categories` must resolve to `category_id`, not the
+     * `categorie_id` the prior naive `rtrim($x, 's')` produced. Without
+     * proper singularization the related-changes finder silently fails to
+     * link child rows to their parent audit entry on every `-ies` plural
+     * (Categories, Stories, Companies, Properties, ...).
+     *
+     * @return void
+     */
+    public function testFindRelatedChangesResolvesIesPluralSource(): void
+    {
+        $mainLog = $this->getAuditLogsTable()->newEntity([
+            'transaction_key' => 'tx-cat-1',
+            'type' => 'create',
+            'source' => 'Categories',
+            'primary_key' => 7,
+            'changed' => ['name' => 'Books'],
+            'created' => new DateTime(),
+        ]);
+        $this->getAuditLogsTable()->save($mainLog);
+
+        $relatedLog = $this->getAuditLogsTable()->newEntity([
+            'transaction_key' => 'tx-cat-1',
+            'type' => 'create',
+            'source' => 'Articles',
+            'primary_key' => 1,
+            'parent_source' => 'Categories',
+            'changed' => ['category_id' => 7, 'title' => 'Hello'],
+            'created' => new DateTime(),
+        ]);
+        $this->getAuditLogsTable()->save($relatedLog);
+
+        $results = $this->getAuditLogsTable()->find('relatedChanges', source: 'Categories', primaryKey: 7)->toArray();
+
+        $this->assertCount(2, $results, 'Both the direct row and the FK-linked child row must be returned.');
+    }
+
+    /**
+     * Regression: irregular plural — `People` must resolve to `person_id`,
+     * not the `peopl_id` the prior naive trim produced.
+     *
+     * @return void
+     */
+    public function testFindRelatedChangesResolvesIrregularPluralSource(): void
+    {
+        $mainLog = $this->getAuditLogsTable()->newEntity([
+            'transaction_key' => 'tx-people-1',
+            'type' => 'create',
+            'source' => 'People',
+            'primary_key' => 42,
+            'changed' => ['name' => 'Ada'],
+            'created' => new DateTime(),
+        ]);
+        $this->getAuditLogsTable()->save($mainLog);
+
+        $relatedLog = $this->getAuditLogsTable()->newEntity([
+            'transaction_key' => 'tx-people-1',
+            'type' => 'create',
+            'source' => 'Addresses',
+            'primary_key' => 1,
+            'parent_source' => 'People',
+            'changed' => ['person_id' => 42, 'city' => 'London'],
+            'created' => new DateTime(),
+        ]);
+        $this->getAuditLogsTable()->save($relatedLog);
+
+        $results = $this->getAuditLogsTable()->find('relatedChanges', source: 'People', primaryKey: 42)->toArray();
+
+        $this->assertCount(2, $results);
+    }
+
+    /**
+     * Regression: uncountable / already-singular source — `News` must
+     * resolve to `news_id`, not the `new_id` the prior trim produced.
+     *
+     * @return void
+     */
+    public function testFindRelatedChangesResolvesUncountableSource(): void
+    {
+        $mainLog = $this->getAuditLogsTable()->newEntity([
+            'transaction_key' => 'tx-news-1',
+            'type' => 'create',
+            'source' => 'News',
+            'primary_key' => 3,
+            'changed' => ['headline' => 'Hi'],
+            'created' => new DateTime(),
+        ]);
+        $this->getAuditLogsTable()->save($mainLog);
+
+        $relatedLog = $this->getAuditLogsTable()->newEntity([
+            'transaction_key' => 'tx-news-1',
+            'type' => 'create',
+            'source' => 'Comments',
+            'primary_key' => 1,
+            'parent_source' => 'News',
+            'changed' => ['news_id' => 3, 'body' => 'first!'],
+            'created' => new DateTime(),
+        ]);
+        $this->getAuditLogsTable()->save($relatedLog);
+
+        $results = $this->getAuditLogsTable()->find('relatedChanges', source: 'News', primaryKey: 3)->toArray();
+
+        $this->assertCount(2, $results);
+    }
+
+    /**
      * Empty filter set must be a pass-through — every audit log row is
      * returned and the helper does not silently inject WHERE clauses.
      *


### PR DESCRIPTION
## Summary

`AuditLogsTable::buildForeignKeyName()` derived the child foreign key from a parent source by stripping a trailing `s` from the snake-cased name. That produced wrong keys for every non-trivial plural:

| Source | Old (broken) | Correct |
|---|---|---|
| Categories | categorie_id | category_id |
| Stories | storie_id | story_id |
| Companies | companie_id | company_id |
| People | peopl_id | person_id |
| Children | childre_id | child_id |
| News | new_id | news_id |

`findRelatedChanges()` uses this key to match `changed` / `original` JSON columns on child rows, so on every table with a non-trivial plural the timeline silently dropped related-row links. The parent audit entry showed only the parent row, with no indication that linked rows existed — a fail-quiet correctness bug.

## Fix

Replace the homegrown `rtrim($x, 's')` with `Inflector::singularize(Inflector::underscore($source))` — the inflection Cake itself uses everywhere else.

## Tests

- Existing `testBuildForeignKeyNameViaPascalCase` continues to pass (UserProfiles -> user_profile_id is correct under both implementations).
- Three new regression tests cover the three classes the old code got wrong:
  - `-ies` plural: `Categories -> category_id`
  - Irregular plural: `People -> person_id`
  - Uncountable / already-singular: `News -> news_id`