### PR TITLE
Snapshot upper id bound at start of chain verification

### DIFF
--- a/src/Service/ChainVerifier.php
+++ b/src/Service/ChainVerifier.php
@@ -49,14 +49,31 @@ class ChainVerifier
         $orderField = $table->aliasField($primaryKey);
         $payloadColumns = array_values(array_diff($table->getSchema()->columns(), self::IGNORED_FIELDS));
 
+        // Snapshot the upper bound at the start of verification. Without
+        // this, a concurrent writer inserting new rows mid-stream — or a
+        // rare delete + re-insert that reuses an id on a non-AUTO_INCREMENT
+        // driver — can lead the chunked `WHERE id > $lastId` walk back into
+        // rows whose prev_hash references a chain link the verifier hasn't
+        // seen yet, producing a false "broken" report. Capturing MAX(id)
+        // upfront gives the verifier a stable point-in-time view; new rows
+        // inserted during verification are simply picked up by the next run.
+        $maxId = (int)($table->find()
+            ->select(['max' => $table->find()->func()->max($orderField)])
+            ->first()
+            ?->get('max') ?? 0);
+
         $total = 0;
         $expectedPrev = null;
         $started = false;
         $lastId = 0;
 
+        if ($maxId === 0) {
+            return ChainVerificationResult::intact(0);
+        }
+
         while (true) {
             $rows = $table->find()
-                ->where([$orderField . ' >' => $lastId])
+                ->where([$orderField . ' >' => $lastId, $orderField . ' <=' => $maxId])
                 ->orderByAsc($orderField)
                 ->limit($chunkSize)
                 ->all();

--- a/tests/TestCase/Service/ChainVerifierTest.php
+++ b/tests/TestCase/Service/ChainVerifierTest.php
@@ -177,6 +177,56 @@ class ChainVerifierTest extends TestCase
         $this->assertSame(1, $result->rowsChecked);
     }
 
+    /**
+     * Regression: verification must snapshot the upper id bound at the
+     * start, otherwise a concurrent writer inserting a fresh row
+     * mid-stream can lead the chunked walk into rows whose prev_hash
+     * references a chain link the verifier hasn't seen yet, producing a
+     * false-broken report (or — rare but possible after a manual delete
+     * + re-insert on a non-AUTO_INCREMENT driver — a re-used id).
+     *
+     * Simulate the concurrent insert with a one-shot `Model.beforeFind`
+     * listener that fires AFTER the verifier has captured its bound but
+     * BEFORE the second chunk runs.
+     */
+    public function testVerifierIgnoresRowsInsertedAfterStart(): void
+    {
+        $table = $this->getTableLocator()->get('AuditLogs');
+
+        $this->persister->logEvents([
+            $this->buildEvent(1, ['title' => 'A']),
+            $this->buildEvent(2, ['title' => 'B']),
+        ]);
+
+        // Drop a third hash-bearing row in DURING verification. The first
+        // `find()` is the MAX(id) snapshot, the second is the chunk walk;
+        // we slip the insert in on the second event so the row exists by
+        // the time chunking starts but is past the snapshot bound.
+        $persister = $this->persister;
+        $self = $this;
+        $listener = function () use ($persister, $self, $table, &$listener): void {
+            static $fired = 0;
+            $fired++;
+            if ($fired !== 2) {
+                return;
+            }
+
+            $persister->logEvents([$self->buildEvent(3, ['title' => 'C-late'])]);
+            $table->getEventManager()->off('Model.beforeFind', $listener);
+        };
+        $table->getEventManager()->on('Model.beforeFind', $listener);
+
+        $result = (new ChainVerifier())->verify($table, 2);
+
+        $this->assertTrue($result->intact, (string)$result->reason);
+        $this->assertSame(
+            2,
+            $result->rowsChecked,
+            'Rows inserted mid-verification (id beyond the captured snapshot) must not be walked.',
+        );
+        $this->assertSame(3, (int)$table->find()->count(), 'The mid-stream insert did actually land in the table.');
+    }
+
     public function testVerifierRejectsNonNumericPrimaryKeys(): void
     {
         $table = $this->getMockBuilder(Table::class)


### PR DESCRIPTION
## Summary

`ChainVerifier` walked the table in chunks of N rows using `WHERE id > $lastId`, with no upper bound. Two concurrent-write scenarios produced false-broken reports:

1. **Mid-stream insert.** A new audit row inserted while verification is running gets its `prev_hash` from the live last-row; if the verifier crosses chunk boundaries while that insert lands, the chunk walk sees a row whose `prev_hash` references a chain link the verifier hasn't seen the live state of.
2. **Re-used id.** A row deleted from the chain and then re-inserted on a non-AUTO_INCREMENT driver can reuse the id, causing the chunk walk to skip into a row from a different point in the chain than expected.

## Fix

Capture `MAX(id)` at verify-start and add `id <= $maxId` to every chunk query. The verifier now operates on a stable point-in-time view; rows inserted while verification is running are picked up by the next run instead. Empty-table case short-circuits to `intact(0)`.

The bound applies per-call; long-running verifications still see only the snapshot they took at the start, which is the desired semantics for a "verify what's there" tool.

## Test

`testVerifierIgnoresRowsInsertedAfterStart` uses a one-shot `Model.beforeFind` listener to insert a third hash-bearing row between the snapshot query and the chunk walk. With the fix `rowsChecked` is 2; without the fix it's 3. Verified by `git stash` + re-running — the test fails on the un-patched code and passes on the patched code.

403 tests pass; phpcs and phpstan are clean.
