### PR TITLE
Replace date function with CakePHP DateTime

### DIFF
--- a/templates/layout/audit_stash.php
+++ b/templates/layout/audit_stash.php
@@ -383,7 +383,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
         <?php } ?>
         <span class="text-light small <?= ($hasAdminBack || $hasBouncerPlugin) ? 'ms-3' : 'ms-auto' ?>" title="<?= __d('audit_stash', 'Server Time') ?>">
             <i class="far fa-clock me-1"></i>
-            <?= date('Y-m-d H:i:s') ?>
+            <?= new \Cake\I18n\DateTime() ?>
         </span>
     </header>
 


### PR DESCRIPTION
This displays the current Datetime in the "correct" format like it is configured in the CakePHP app just like any other dates also so.