### PR TITLE
Make audit_logs.primary_key type configurable via Polymorphic.type

### DIFF
--- a/config/Migrations/20171018185609_CreateAuditLogs.php
+++ b/config/Migrations/20171018185609_CreateAuditLogs.php
@@ -14,11 +14,19 @@ class CreateAuditLogs extends BaseMigration
      */
     public function up(): void
     {
-        // primary_key stores the audited record's primary key (polymorphic), so it
-        // follows the application's primary-key signedness. The flag is false
-        // (signed) when unset, so an unset flag yields a signed column matching the
-        // default-signed ids it references. Unsigned only on MySQL.
+        // primary_key stores the audited record's primary key (polymorphic), so its
+        // type follows the global Polymorphic.type config (default: integer). For
+        // integer variants, signedness follows Migrations.unsigned_primary_keys.
+        $type = (string)Configure::read('Polymorphic.type', 'integer');
         $signed = !(bool)Configure::read('Migrations.unsigned_primary_keys', false);
+
+        $polymorphicOptions = [
+            'default' => null,
+            'null' => true,
+        ];
+        if (in_array($type, ['integer', 'biginteger'], true)) {
+            $polymorphicOptions['signed'] = $signed;
+        }
 
         $this->table('audit_logs')
             ->addColumn('id', 'integer', [
@@ -39,12 +47,7 @@ class CreateAuditLogs extends BaseMigration
                 'limit' => 7,
                 'null' => false,
             ])
-            ->addColumn('primary_key', 'integer', [
-                'default' => null,
-                'limit' => 10,
-                'null' => true,
-                'signed' => $signed,
-            ])
+            ->addColumn('primary_key', $type, $polymorphicOptions)
             ->addColumn('display_value', 'string', [
                 'default' => null,
                 'limit' => 255,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -74,9 +74,17 @@ The `audit_logs.primary_key` column stores the audited record's primary key (a p
 type is controlled by the global `Polymorphic.type` config key (default: `integer`):
 
 ```php
-// config/app.php or config/app_local.php
-Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
+// config/app.php (merged into Configure at bootstrap, including the migrations CLI)
+'Polymorphic' => [
+    'type' => 'uuid', // integer (default) | biginteger | uuid | binaryuuid
+],
 ```
+
+::: warning Fresh installs only
+This config key is read at migration time to decide the column type for `audit_logs.primary_key`.
+Changing it has no effect on existing installs that have already run the migration — the column already exists with its original type.
+To change the column type on an existing install, write an app-side migration that `ALTER`s the column accordingly.
+:::
 
 | Value | Column type | Signedness |
 |---|---|---|

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -68,25 +68,25 @@ Notes:
 - If you want to access the timestamp as a `DateTime` object (e.g. in a custom persister) without
   re-parsing the string, use `BaseEvent::getTimestampObject()`.
 
-### UUID Primary Keys
+### Polymorphic Primary Key Type
 
-The default migration creates the `primary_key` column as an integer. If your application uses UUID primary keys,
-you need to copy and adjust the migration on the app side:
-
-```bash
-# Copy the migration to your app
-cp vendor/dereuromark/cakephp-audit-stash/config/Migrations/20171018185609_CreateAuditLogs.php config/Migrations/
-```
-
-Then modify the `primary_key` column definition:
+The `audit_logs.primary_key` column stores the audited record's primary key (a polymorphic foreign key). Its column
+type is controlled by the global `Polymorphic.type` config key (default: `integer`):
 
 ```php
-->addColumn('primary_key', 'string', [
-    'default' => null,
-    'limit' => 36,
-    'null' => true,
-])
+// config/app.php or config/app_local.php
+Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
 ```
+
+| Value | Column type | Signedness |
+|---|---|---|
+| `integer` (default) | `INT` | follows `Migrations.unsigned_primary_keys` |
+| `biginteger` | `BIGINT` | follows `Migrations.unsigned_primary_keys` |
+| `uuid` | `CHAR(36)` | n/a |
+| `binaryuuid` | `BINARY(16)` | n/a |
+
+For the `integer` and `biginteger` variants, signedness is inherited from the `Migrations.unsigned_primary_keys`
+config key (same as CakePHP core migrations). For `uuid` and `binaryuuid` no `signed` option is set.
 
 The table persister is configured by default, but you can explicitly set it in your `config/app_local.php` or `config/app.php`:
 


### PR DESCRIPTION
## Problem

`audit_logs.primary_key` (the audited record's id) is a polymorphic reference — it points at an arbitrary audited record's primary key, so its column type should match whatever that record uses. It was hardcoded as `integer`, which cannot match apps whose records use `biginteger` or UUID primary keys.

## Fix

The polymorphic column now follows a single global config key, `Polymorphic.type`, shared across the polymorphic-FK plugins:

```php
// config/app.php or config/app_local.php
Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
```

- Default `integer` (the CakePHP default), so behavior is unchanged for the common case.
- For the integer variants, signedness follows `Migrations.unsigned_primary_keys`; `uuid` / `binaryuuid` set no signedness.

Editing the create migration sets the default for fresh installs; existing installs are unaffected (the create migration does not re-run). Type/signedness only take effect on MySQL for the integer variants.
