### PR TITLE
Fix N^2 audit duplication on bulk deleteMany

### DIFF
--- a/src/Model/Behavior/AuditLogBehavior.php
+++ b/src/Model/Behavior/AuditLogBehavior.php
@@ -349,6 +349,13 @@ class AuditLogBehavior extends Behavior
 
         $data = $this->_table->dispatchEvent('AuditStash.beforeLog', ['logs' => $events]);
         $this->persister()->logEvents($data->getData('logs'));
+
+        // Reset the queue after flushing. The same options object (and thus the
+        // same queue) is shared across every entity of a bulk operation, while
+        // `Model.afterDeleteCommit`/`afterSaveCommit` is dispatched once per
+        // entity. Without this, each subsequent dispatch would re-persist the
+        // whole queue, turning N bulk deletes into N*N audit records.
+        $options['_auditQueue'] = new SplObjectStorage();
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/AuditIntegrationTest.php
+++ b/tests/TestCase/Model/Behavior/AuditIntegrationTest.php
@@ -9,6 +9,7 @@ use AuditStash\Event\AuditDeleteEvent;
 use AuditStash\Event\AuditUpdateEvent;
 use AuditStash\Model\Behavior\AuditLogBehavior;
 use AuditStash\Test\DebugPersister;
+use Cake\Core\Configure;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
@@ -367,6 +368,107 @@ class AuditIntegrationTest extends TestCase
             });
 
         $this->table->delete($entity);
+    }
+
+    /**
+     * Tests that a bulk deleteMany logs exactly one audit event per entity.
+     *
+     * Regression test for the N^2 duplication: CakePHP shares a single options
+     * object (and therefore one `_auditQueue`) across all entities of a
+     * `deleteMany()` and then dispatches `Model.afterDeleteCommit` once per
+     * entity. Before the fix every dispatch re-flushed the whole queue, so
+     * deleting N rows produced N*N audit records.
+     *
+     * @return void
+     */
+    public function testDeleteManyLogsOneEventPerEntity()
+    {
+        $entities = $this->table->find()->all()->toList();
+        $count = count($entities);
+        $this->assertGreaterThan(1, $count, 'Need multiple rows to exercise the bulk path.');
+
+        $persistedIds = [];
+        $this->persister
+            ->expects($this->atLeastOnce())
+            ->method('logEvents')
+            ->willReturnCallback(function (array $events) use (&$persistedIds): void {
+                foreach ($events as $event) {
+                    $this->assertInstanceOf(AuditDeleteEvent::class, $event);
+                    $persistedIds[] = $event->getId();
+                }
+            });
+
+        $this->table->deleteManyOrFail($entities);
+
+        // Exactly one event per entity (was $count * $count before the fix).
+        $this->assertCount(
+            $count,
+            $persistedIds,
+            'deleteMany must log exactly one audit event per entity, not N^2.',
+        );
+        // And every entity logged once, none duplicated.
+        $expectedIds = array_map(
+            fn ($entity): mixed => $entity->get('id'),
+            $entities,
+        );
+        sort($expectedIds);
+        sort($persistedIds);
+        $this->assertSame($expectedIds, $persistedIds);
+    }
+
+    /**
+     * Tests that the `afterSave` save strategy also logs exactly one event per
+     * entity on a bulk deleteMany.
+     *
+     * In this strategy `afterCommit()` is invoked inline (per entity, during the
+     * transaction) instead of via the commit events. The events accumulate in
+     * the shared queue, so without clearing it every inline flush re-persisted
+     * the already-queued events (1 + 2 + ... + N records).
+     *
+     * @return void
+     */
+    public function testDeleteManyWithAfterSaveStrategyLogsOneEventPerEntity()
+    {
+        Configure::write('AuditStash.saveType', 'afterSave');
+        try {
+            // Build a fresh, isolated table so the behavior is only ever
+            // registered with the afterSave strategy (implementedEvents is
+            // evaluated when the behavior is added).
+            $locator = $this->getTableLocator();
+            $locator->clear();
+
+            $table = $locator->get('Articles');
+            $table->addBehavior('AuditLog', [
+                'className' => AuditLogBehavior::class,
+            ]);
+            $table->behaviors()->get('AuditLog')->persister($this->persister);
+
+            $entities = $table->find()->all()->toList();
+            $count = count($entities);
+            $this->assertGreaterThan(1, $count, 'Need multiple rows to exercise the bulk path.');
+
+            $persistedIds = [];
+            $this->persister
+                ->expects($this->atLeastOnce())
+                ->method('logEvents')
+                ->willReturnCallback(function (array $events) use (&$persistedIds): void {
+                    foreach ($events as $event) {
+                        $this->assertInstanceOf(AuditDeleteEvent::class, $event);
+                        $persistedIds[] = $event->getId();
+                    }
+                });
+
+            $table->deleteManyOrFail($entities);
+
+            $this->assertCount(
+                $count,
+                $persistedIds,
+                'afterSave strategy must log exactly one audit event per entity.',
+            );
+        } finally {
+            Configure::write('AuditStash.saveType', null);
+            $this->getTableLocator()->clear();
+        }
     }
 
     /**


### PR DESCRIPTION
## Fix N² audit duplication on bulk `deleteMany`

Addresses the duplication reported in #75. Deleting N entities in one
`deleteMany()` / `deleteManyOrFail()` produced **N² audit records** instead of N
(the reporter saw 7 deletes → 49 rows), all sharing one `transaction_key`.

### Root cause

CakePHP's `_deleteMany()` shares a **single** options object — and therefore one
`_auditQueue` (`SplObjectStorage`) — across every entity in the bulk transaction,
then dispatches `Model.afterDeleteCommit` **once per entity**. `afterCommit()`
flushed the entire shared queue on every dispatch but never cleared it, so each
subsequent dispatch re-persisted everything already written → N×N.

This has been latent since the queue design was introduced in 2015; it surfaces
on `deleteMany` because that is the path where CakePHP both shares the queue and
fires the commit event per entity. Single saves/deletes flush once, so the
missing reset was harmless there.

### Fix

Reset the queue after each flush in `afterCommit()`:

```php
$this->persister()->logEvents($data->getData('logs'));

// Reset the queue after flushing; the same options object (and queue) is
// shared across every entity of a bulk operation while the commit event
// is dispatched once per entity.
$options['_auditQueue'] = new SplObjectStorage();
```

This also fixes a latent **triangular** duplication in the `afterSave` save
strategy (`AuditStash.saveType = afterSave`), where `afterCommit()` is invoked
inline per entity during the transaction (deleting 3 logged 1+2+3 = 6 rows
before, 3 now).

### Safety across the paths the reporter flagged

I traced the CakePHP 5.3 event flow to confirm the reset cannot drop events:

- **Saves with audited associations** — associated saves run with
  `_primary => false` and share the same queue via `getArrayCopy()`; only the
  primary parent dispatches the commit event, so the queue is flushed exactly
  once. Existing association tests stay green.
- **`cascadeDeletes => true`** — cascade children are captured into the same
  shared queue and the parent dispatches the commit event once. Existing cascade
  tests stay green.
- **`afterSave` strategy** — covered by a new test; the reset removes the
  pre-existing triangular duplication there too.

### Tests

- `testDeleteManyLogsOneEventPerEntity` — N entities → N audit events (was N²).
- `testDeleteManyWithAfterSaveStrategyLogsOneEventPerEntity` — same guarantee
  under the `afterSave` strategy.

Both fail on `master` and pass with the fix. Full suite green (405 tests); no new
PHPStan/PHPCS findings.

> Note: the secondary observation in #75 — `saveMany()` logging **nothing** by
> default — is a separate pre-existing issue (CakePHP discards the per-entity
> audit queue for `saveMany`) and is handled in a follow-up PR.
