### PR TITLE
Fix saveMany() logging no audit records

### DIFF
--- a/src/Model/Behavior/AuditLogBehavior.php
+++ b/src/Model/Behavior/AuditLogBehavior.php
@@ -24,6 +24,7 @@ use Cake\Utility\Text;
 use SplObjectStorage;
 use Stringable;
 use UnitEnum;
+use WeakMap;
 use function Cake\Collection\collection;
 
 /**
@@ -78,6 +79,26 @@ class AuditLogBehavior extends Behavior
     protected ?PersisterInterface $persister = null;
 
     /**
+     * Audit queues kept alive across a `Table::saveMany()` bulk operation,
+     * keyed by the primary entity. CakePHP discards the per-entity options
+     * (and its queue) before the deferred `Model.afterSaveCommit` fires, so the
+     * queue is stashed here at `beforeSave` time and retrieved in
+     * `afterCommit()`. A `WeakMap` is used so entries vanish automatically if a
+     * bulk save rolls back (the commit event never fires to clean them up).
+     *
+     * @var \WeakMap<\Cake\Datasource\EntityInterface, \SplObjectStorage<\Cake\Datasource\EntityInterface, \AuditStash\Event\BaseEvent>>
+     */
+    protected WeakMap $bulkSaveQueues;
+
+    /**
+     * @inheritDoc
+     */
+    public function initialize(array $config): void
+    {
+        $this->bulkSaveQueues = new WeakMap();
+    }
+
+    /**
      * Returns the list of implemented events.
      *
      * @return array
@@ -120,6 +141,23 @@ class AuditLogBehavior extends Behavior
 
         if (!isset($options['_auditQueue'])) {
             $options['_auditQueue'] = new SplObjectStorage();
+        }
+
+        // Inside a saveMany() the per-entity options (and queue) are discarded
+        // before the deferred afterSaveCommit fires, so keep a reference to the
+        // queue keyed by the primary entity. Associated saves share this same
+        // queue, so afterCommit() can flush parent and children together once
+        // the outer transaction has committed. Registered on the primary entity
+        // regardless of whether it produces an event, so association-only
+        // changes are not lost.
+        if (
+            $event->getName() === 'Model.beforeSave'
+            && ($options['_primary'] ?? false)
+            && $this->isBulkSave($options)
+        ) {
+            /** @var \SplObjectStorage<\Cake\Datasource\EntityInterface, \AuditStash\Event\BaseEvent> $queue */
+            $queue = $options['_auditQueue'];
+            $this->bulkSaveQueues[$entity] = $queue;
         }
 
         // Capture cascade-deleted dependent records before they are deleted
@@ -320,6 +358,25 @@ class AuditLogBehavior extends Behavior
     }
 
     /**
+     * Determines whether the current save runs inside a `Table::saveMany()`
+     * bulk operation.
+     *
+     * `Table::saveMany()` is the only core path that sets `_cleanOnSuccess` to
+     * `false`, which makes it a reliable marker for the bulk-save case where the
+     * per-entity options (and audit queue) are discarded before the deferred
+     * commit event fires. See {@see self::injectTracking()} and
+     * {@see self::afterCommit()} for how the queue is kept alive across it.
+     *
+     * @param \ArrayObject $options The save options
+     *
+     * @return bool
+     */
+    protected function isBulkSave(ArrayObject $options): bool
+    {
+        return ($options['_cleanOnSuccess'] ?? true) === false;
+    }
+
+    /**
      * Persists all audit log events stored in the `_eventQueue` key inside $options.
      *
      * @param \Cake\Event\Event $event The Model event that is enclosed inside a transaction
@@ -333,29 +390,36 @@ class AuditLogBehavior extends Behavior
         EntityInterface $entity,
         ArrayObject $options,
     ): void {
-        if (!isset($options['_auditQueue'])) {
+        // The queue normally lives on the (shared) options object. For a
+        // saveMany() the per-entity options are discarded before this deferred
+        // commit event fires, so fall back to the queue stashed by entity in
+        // injectTracking().
+        /** @var \SplObjectStorage<\Cake\Datasource\EntityInterface, \AuditStash\Event\BaseEvent>|null $queue */
+        $queue = $options['_auditQueue'] ?? ($this->bulkSaveQueues[$entity] ?? null);
+        if ($queue === null) {
             return;
         }
 
-        /** @var \SplObjectStorage<\Cake\Datasource\EntityInterface, \AuditStash\Event\BaseEvent> $queue */
-        $queue = $options['_auditQueue'];
         $events = collection($queue)
             ->map(fn ($entity, $pos, $it): mixed => $it->getInfo())
             ->toList();
 
-        if (!$events) {
-            return;
+        if ($events) {
+            $data = $this->_table->dispatchEvent('AuditStash.beforeLog', ['logs' => $events]);
+            $this->persister()->logEvents($data->getData('logs'));
         }
 
-        $data = $this->_table->dispatchEvent('AuditStash.beforeLog', ['logs' => $events]);
-        $this->persister()->logEvents($data->getData('logs'));
-
-        // Reset the queue after flushing. The same options object (and thus the
-        // same queue) is shared across every entity of a bulk operation, while
-        // `Model.afterDeleteCommit`/`afterSaveCommit` is dispatched once per
-        // entity. Without this, each subsequent dispatch would re-persist the
-        // whole queue, turning N bulk deletes into N*N audit records.
-        $options['_auditQueue'] = new SplObjectStorage();
+        // Forget the queue after flushing. For a bulk delete the same options
+        // (and queue) is shared while `Model.afterDeleteCommit` is dispatched
+        // once per entity; without resetting, each dispatch would re-persist the
+        // whole queue (N deletes -> N*N records). For a saveMany the stashed
+        // per-entity queue is dropped once consumed.
+        if (isset($options['_auditQueue'])) {
+            $options['_auditQueue'] = new SplObjectStorage();
+        }
+        if (isset($this->bulkSaveQueues[$entity])) {
+            unset($this->bulkSaveQueues[$entity]);
+        }
     }
 
     /**

--- a/src/Model/Behavior/AuditLogBehavior.php
+++ b/src/Model/Behavior/AuditLogBehavior.php
@@ -349,6 +349,13 @@ class AuditLogBehavior extends Behavior
 
         $data = $this->_table->dispatchEvent('AuditStash.beforeLog', ['logs' => $events]);
         $this->persister()->logEvents($data->getData('logs'));
+
+        // Reset the queue after flushing. The same options object (and thus the
+        // same queue) is shared across every entity of a bulk operation, while
+        // `Model.afterDeleteCommit`/`afterSaveCommit` is dispatched once per
+        // entity. Without this, each subsequent dispatch would re-persist the
+        // whole queue, turning N bulk deletes into N*N audit records.
+        $options['_auditQueue'] = new SplObjectStorage();
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/AuditIntegrationTest.php
+++ b/tests/TestCase/Model/Behavior/AuditIntegrationTest.php
@@ -9,6 +9,7 @@ use AuditStash\Event\AuditDeleteEvent;
 use AuditStash\Event\AuditUpdateEvent;
 use AuditStash\Model\Behavior\AuditLogBehavior;
 use AuditStash\Test\DebugPersister;
+use Cake\Core\Configure;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
@@ -367,6 +368,107 @@ class AuditIntegrationTest extends TestCase
             });
 
         $this->table->delete($entity);
+    }
+
+    /**
+     * Tests that a bulk deleteMany logs exactly one audit event per entity.
+     *
+     * Regression test for the N^2 duplication: CakePHP shares a single options
+     * object (and therefore one `_auditQueue`) across all entities of a
+     * `deleteMany()` and then dispatches `Model.afterDeleteCommit` once per
+     * entity. Before the fix every dispatch re-flushed the whole queue, so
+     * deleting N rows produced N*N audit records.
+     *
+     * @return void
+     */
+    public function testDeleteManyLogsOneEventPerEntity()
+    {
+        $entities = $this->table->find()->all()->toList();
+        $count = count($entities);
+        $this->assertGreaterThan(1, $count, 'Need multiple rows to exercise the bulk path.');
+
+        $persistedIds = [];
+        $this->persister
+            ->expects($this->atLeastOnce())
+            ->method('logEvents')
+            ->willReturnCallback(function (array $events) use (&$persistedIds): void {
+                foreach ($events as $event) {
+                    $this->assertInstanceOf(AuditDeleteEvent::class, $event);
+                    $persistedIds[] = $event->getId();
+                }
+            });
+
+        $this->table->deleteManyOrFail($entities);
+
+        // Exactly one event per entity (was $count * $count before the fix).
+        $this->assertCount(
+            $count,
+            $persistedIds,
+            'deleteMany must log exactly one audit event per entity, not N^2.',
+        );
+        // And every entity logged once, none duplicated.
+        $expectedIds = array_map(
+            fn ($entity): mixed => $entity->get('id'),
+            $entities,
+        );
+        sort($expectedIds);
+        sort($persistedIds);
+        $this->assertSame($expectedIds, $persistedIds);
+    }
+
+    /**
+     * Tests that the `afterSave` save strategy also logs exactly one event per
+     * entity on a bulk deleteMany.
+     *
+     * In this strategy `afterCommit()` is invoked inline (per entity, during the
+     * transaction) instead of via the commit events. The events accumulate in
+     * the shared queue, so without clearing it every inline flush re-persisted
+     * the already-queued events (1 + 2 + ... + N records).
+     *
+     * @return void
+     */
+    public function testDeleteManyWithAfterSaveStrategyLogsOneEventPerEntity()
+    {
+        Configure::write('AuditStash.saveType', 'afterSave');
+        try {
+            // Build a fresh, isolated table so the behavior is only ever
+            // registered with the afterSave strategy (implementedEvents is
+            // evaluated when the behavior is added).
+            $locator = $this->getTableLocator();
+            $locator->clear();
+
+            $table = $locator->get('Articles');
+            $table->addBehavior('AuditLog', [
+                'className' => AuditLogBehavior::class,
+            ]);
+            $table->behaviors()->get('AuditLog')->persister($this->persister);
+
+            $entities = $table->find()->all()->toList();
+            $count = count($entities);
+            $this->assertGreaterThan(1, $count, 'Need multiple rows to exercise the bulk path.');
+
+            $persistedIds = [];
+            $this->persister
+                ->expects($this->atLeastOnce())
+                ->method('logEvents')
+                ->willReturnCallback(function (array $events) use (&$persistedIds): void {
+                    foreach ($events as $event) {
+                        $this->assertInstanceOf(AuditDeleteEvent::class, $event);
+                        $persistedIds[] = $event->getId();
+                    }
+                });
+
+            $table->deleteManyOrFail($entities);
+
+            $this->assertCount(
+                $count,
+                $persistedIds,
+                'afterSave strategy must log exactly one audit event per entity.',
+            );
+        } finally {
+            Configure::write('AuditStash.saveType', null);
+            $this->getTableLocator()->clear();
+        }
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/AuditIntegrationTest.php
+++ b/tests/TestCase/Model/Behavior/AuditIntegrationTest.php
@@ -10,6 +10,7 @@ use AuditStash\Event\AuditUpdateEvent;
 use AuditStash\Model\Behavior\AuditLogBehavior;
 use AuditStash\Test\DebugPersister;
 use Cake\Core\Configure;
+use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
@@ -346,6 +347,148 @@ class AuditIntegrationTest extends TestCase
             });
 
         $this->table->save($entity);
+    }
+
+    /**
+     * Tests that a bulk saveMany logs exactly one audit event per entity.
+     *
+     * Regression test for saveMany logging nothing: CakePHP casts the options
+     * to a plain array and re-wraps them per entity inside `Table::saveMany()`,
+     * so the per-entity `_auditQueue` is discarded before the deferred
+     * `Model.afterSaveCommit` fires on the (queue-less) outer options. Without
+     * the bulk-save detection the audit log stayed empty for saveMany.
+     *
+     * @return void
+     */
+    public function testSaveManyLogsOneEventPerEntity()
+    {
+        $entities = [
+            $this->table->newEntity(['title' => 'Bulk 1', 'body' => 'b1']),
+            $this->table->newEntity(['title' => 'Bulk 2', 'body' => 'b2']),
+            $this->table->newEntity(['title' => 'Bulk 3', 'body' => 'b3']),
+        ];
+
+        $persisted = [];
+        $this->persister
+            ->expects($this->atLeastOnce())
+            ->method('logEvents')
+            ->willReturnCallback(function (array $events) use (&$persisted): void {
+                foreach ($events as $event) {
+                    $this->assertInstanceOf(AuditCreateEvent::class, $event);
+                    $this->assertSame('Articles', $event->getSourceName());
+                    $persisted[] = $event;
+                }
+            });
+
+        $this->table->saveManyOrFail($entities);
+
+        // One create event per entity (was zero before the fix).
+        $this->assertCount(count($entities), $persisted);
+        $titles = array_map(fn ($event): mixed => $event->getChanged()['title'], $persisted);
+        sort($titles);
+        $this->assertSame(['Bulk 1', 'Bulk 2', 'Bulk 3'], $titles);
+    }
+
+    /**
+     * Tests that a bulk saveMany of entities with audited hasMany children logs
+     * every parent and child exactly once (no duplicates, none dropped), with
+     * each parent sharing a transaction id with its own children.
+     *
+     * @return void
+     */
+    public function testSaveManyWithHasManyLogsAllEvents()
+    {
+        $this->table->Comments->addBehavior('AuditLog', [
+            'className' => AuditLogBehavior::class,
+        ]);
+
+        $entities = [
+            $this->table->newEntity([
+                'title' => 'Parent 1',
+                'body' => 'b1',
+                'comments' => [['comment' => 'c1', 'user_id' => 1]],
+            ]),
+            $this->table->newEntity([
+                'title' => 'Parent 2',
+                'body' => 'b2',
+                'comments' => [['comment' => 'c2', 'user_id' => 1]],
+            ]),
+        ];
+
+        $persisted = [];
+        $this->persister
+            ->expects($this->atLeastOnce())
+            ->method('logEvents')
+            ->willReturnCallback(function (array $events) use (&$persisted): void {
+                foreach ($events as $event) {
+                    $persisted[] = $event;
+                }
+            });
+
+        $this->table->saveManyOrFail($entities);
+
+        // 2 articles + 2 comments, each logged exactly once.
+        $this->assertCount(4, $persisted);
+
+        $bySource = [];
+        foreach ($persisted as $event) {
+            $bySource[$event->getSourceName()][] = $event;
+        }
+        $this->assertCount(2, $bySource['Articles']);
+        $this->assertCount(2, $bySource['Comments']);
+
+        // Each comment shares its transaction id with exactly one article.
+        $articleTransactions = array_map(
+            fn ($event): string => $event->getTransactionId(),
+            $bySource['Articles'],
+        );
+        foreach ($bySource['Comments'] as $comment) {
+            $this->assertContains(
+                $comment->getTransactionId(),
+                $articleTransactions,
+                'Each child must be grouped under its parent transaction id.',
+            );
+        }
+    }
+
+    /**
+     * Tests that a rolled-back saveMany does not write phantom audit records.
+     *
+     * Audit events must only be persisted after the surrounding transaction
+     * commits. If a later entity aborts the bulk save, the whole transaction
+     * rolls back and nothing must have been logged for the entities saved
+     * earlier in the same operation.
+     *
+     * @return void
+     */
+    public function testSaveManyRollbackDoesNotLogPhantomRecords()
+    {
+        // Abort the save of the second entity, rolling back the whole saveMany.
+        $this->table->getEventManager()->on(
+            'Model.beforeSave',
+            function ($event, $entity, $options): void {
+                if ($entity->get('title') === 'Boom') {
+                    $event->setResult(false);
+                    $event->stopPropagation();
+                }
+            },
+        );
+
+        $this->persister
+            ->expects($this->never())
+            ->method('logEvents');
+
+        $entities = [
+            $this->table->newEntity(['title' => 'Good', 'body' => 'b']),
+            $this->table->newEntity(['title' => 'Boom', 'body' => 'b']),
+        ];
+
+        try {
+            $this->table->saveManyOrFail($entities);
+            $this->fail('Expected PersistenceFailedException was not thrown.');
+        } catch (PersistenceFailedException) {
+            // Expected: the bulk save aborted and rolled back.
+        }
     }
 
     /**


### PR DESCRIPTION
## Fix `saveMany()` logging no audit records

Addresses the secondary observation in #75: `saveManyOrFail()` / `saveMany()`
logged **0 audit records** by default.

> [!NOTE]
> Stacked on #76 (the `deleteMany` N² fix) and targets `master`; the queue
> reset added there is reused here. Please merge #76 first — once it lands this
> branch can be rebased onto `master`.

### Root cause

`Table::saveMany()` casts its options to a plain array and re-wraps them into a
fresh `ArrayObject` for each inner `Table::save()` (`Table.php:2363`). The audit
queue is therefore created on a throwaway per-entity options object, while the
deferred `Model.afterSaveCommit` is dispatched on the **outer** options that
never received a queue — so `afterCommit()` returned early and nothing was
logged. (`deleteMany` does not hit this because it shares the outer options
object directly, which is why it logged — duplicated — instead.)

### Fix

Keep the per-entity queue reachable from the deferred commit event, keyed by the
primary entity:

- `injectTracking()` stashes the queue in a `WeakMap` (`bulkSaveQueues`) when a
  save is the primary entity of a bulk operation (`Table::saveMany()` is the only
  core path that sets `_cleanOnSuccess => false`).
- `afterCommit()` falls back to that stashed queue when the options carry none,
  flushes it, and drops the entry.

A `WeakMap` is used deliberately: if the bulk save **rolls back**, the deferred
commit event never fires, and the entry vanishes automatically when the entity
is garbage-collected — no leak, and no flush.

### Why flush at commit time (not eagerly)

An earlier iteration flushed eagerly inside `afterSave()`. That writes audit rows
*during* the transaction, so a rolled-back `saveMany()` would leave phantom
records with any persister not enlisted in the same DB transaction
(`ElasticSearchPersister`, or a `TablePersister` on another connection) — a
regression from the default "log only after commit" guarantee, and dangerous
with the hash-chain tamper-evidence feature. The `WeakMap` approach preserves
after-commit semantics for every persister.

### Behavior notes

- Associated records saved within a `saveMany()` (audited hasMany/belongsTo) are
  flushed together with their parent and share the parent's transaction id.
- Each top-level entity in a `saveMany()` keeps its own transaction id, matching
  how CakePHP treats each inner save. To group an entire bulk save under one id,
  pass `_auditTransaction` explicitly in the save options.
- The `afterSave` save strategy and single saves are unaffected.

### Tests

- `testSaveManyLogsOneEventPerEntity` — N entities → N create events (was 0).
- `testSaveManyWithHasManyLogsAllEvents` — parent + audited children all logged
  once, each child grouped under its parent transaction id.
- `testSaveManyRollbackDoesNotLogPhantomRecords` — an aborted bulk save logs
  nothing.

All fail on the base and pass with the fix. Full suite green (408 tests); no new
PHPStan/PHPCS findings.
