### PR TITLE
Fix PHPCS issues after sniffer update

### DIFF
--- a/src/Meta/RequestMetadata.php
+++ b/src/Meta/RequestMetadata.php
@@ -44,7 +44,7 @@ class RequestMetadata implements EventListenerInterface
      */
     public function __construct(
         Request $request,
-        int|string|null $userId = null,
+        string|int|null $userId = null,
         ?string $userDisplay = null,
     ) {
         $this->request = $request;

--- a/src/Persister/ExtractionTrait.php
+++ b/src/Persister/ExtractionTrait.php
@@ -113,7 +113,7 @@ trait ExtractionTrait
      */
     protected function extractMetaFields(
         EventInterface $event,
-        bool|array $fields,
+        array|bool $fields,
         bool $unsetExtracted = true,
         bool $serialize = true,
     ): array {

--- a/src/Persister/TablePersister.php
+++ b/src/Persister/TablePersister.php
@@ -159,7 +159,7 @@ class TablePersister implements PersisterInterface
      *
      * @return $this
      */
-    public function setTable(string|Table|null $table)
+    public function setTable(Table|string|null $table)
     {
         if (is_string($table)) {
             $table = $this->getTableLocator()->get($table);

--- a/src/Service/GdprService.php
+++ b/src/Service/GdprService.php
@@ -39,7 +39,7 @@ class GdprService
      *
      * @return \Cake\ORM\Query\SelectQuery
      */
-    public function findByUser(int|string $userId): SelectQuery
+    public function findByUser(string|int $userId): SelectQuery
     {
         /** @var \AuditStash\Model\Table\AuditLogsTable $auditLogsTable */
         $auditLogsTable = $this->fetchTable('AuditStash.AuditLogs');
@@ -63,7 +63,7 @@ class GdprService
      *
      * @return int Number of records anonymized
      */
-    public function anonymize(int|string $userId, array $options = []): int
+    public function anonymize(string|int $userId, array $options = []): int
     {
         /** @var \AuditStash\Model\Table\AuditLogsTable $auditLogsTable */
         $auditLogsTable = $this->fetchTable('AuditStash.AuditLogs');
@@ -144,7 +144,7 @@ class GdprService
      *
      * @return int Number of records deleted
      */
-    public function delete(int|string $userId): int
+    public function delete(string|int $userId): int
     {
         /** @var \AuditStash\Model\Table\AuditLogsTable $auditLogsTable */
         $auditLogsTable = $this->fetchTable('AuditStash.AuditLogs');
@@ -162,7 +162,7 @@ class GdprService
      *
      * @return array<mixed>|string
      */
-    public function export(int|string $userId, string $format = 'json'): array|string
+    public function export(string|int $userId, string $format = 'json'): array|string
     {
         $data = [];
 
@@ -206,7 +206,7 @@ class GdprService
      *
      * @return array<string, mixed>
      */
-    public function getStats(int|string $userId): array
+    public function getStats(string|int $userId): array
     {
         /** @var \AuditStash\Model\Table\AuditLogsTable $auditLogsTable */
         $auditLogsTable = $this->fetchTable('AuditStash.AuditLogs');
@@ -264,7 +264,7 @@ class GdprService
      *
      * @return string|null
      */
-    protected function generateAnonymizedUserId(int|string $userId, string $strategy): ?string
+    protected function generateAnonymizedUserId(string|int $userId, string $strategy): ?string
     {
         return match ($strategy) {
             'hash' => $this->hashUserId($userId),
@@ -281,7 +281,7 @@ class GdprService
      *
      * @return string
      */
-    protected function hashUserId(int|string $userId): string
+    protected function hashUserId(string|int $userId): string
     {
         return 'anon_' . substr(hash('sha256', $userId . Configure::read('Security.salt', '')), 0, 8);
     }

--- a/src/Service/RevertService.php
+++ b/src/Service/RevertService.php
@@ -38,7 +38,7 @@ class RevertService
      *
      * @return \Cake\Datasource\EntityInterface|false
      */
-    public function revertFull(string $source, int|string $primaryKey, int $auditLogId): EntityInterface|false
+    public function revertFull(string $source, string|int $primaryKey, int $auditLogId): EntityInterface|false
     {
         $this->assertEnabled();
 
@@ -81,7 +81,7 @@ class RevertService
      *
      * @return \Cake\Datasource\EntityInterface|false
      */
-    public function revertPartial(string $source, int|string $primaryKey, int $auditLogId, array $fields): EntityInterface|false
+    public function revertPartial(string $source, string|int $primaryKey, int $auditLogId, array $fields): EntityInterface|false
     {
         $this->assertEnabled();
 
@@ -125,7 +125,7 @@ class RevertService
      *
      * @return \Cake\Datasource\EntityInterface|false
      */
-    public function restoreDeleted(string $source, int|string $primaryKey): EntityInterface|false
+    public function restoreDeleted(string $source, string|int $primaryKey): EntityInterface|false
     {
         $this->assertEnabled();
 
@@ -207,7 +207,7 @@ class RevertService
      */
     protected function createRevertAudit(
         string $source,
-        int|string $primaryKey,
+        string|int $primaryKey,
         int $auditLogId,
         string $revertType,
         array $currentState,

--- a/src/Service/StateReconstructorService.php
+++ b/src/Service/StateReconstructorService.php
@@ -23,7 +23,7 @@ class StateReconstructorService
      *
      * @return array Reconstructed data
      */
-    public function reconstructState(string $source, int|string $primaryKey, int $auditLogId): array
+    public function reconstructState(string $source, string|int $primaryKey, int $auditLogId): array
     {
         $auditLogs = $this->fetchTable('AuditStash.AuditLogs');
 

--- a/src/View/Helper/AuditHelper.php
+++ b/src/View/Helper/AuditHelper.php
@@ -506,10 +506,10 @@ class AuditHelper extends Helper
      * @return array|string|null URL or null if no link
      */
     protected function buildUserUrl(
-        callable|string|array $linkConfig,
+        callable|array|string $linkConfig,
         string $user,
         string $displayName,
-    ): string|array|null {
+    ): array|string|null {
         if (is_callable($linkConfig)) {
             return $linkConfig($user, $displayName);
         }
@@ -573,11 +573,11 @@ class AuditHelper extends Helper
      * @return array|string|null URL or null if no link
      */
     protected function buildRecordUrl(
-        callable|string|array $linkConfig,
+        callable|array|string $linkConfig,
         string $source,
         string $primaryKey,
         string $displayValue,
-    ): string|array|null {
+    ): array|string|null {
         if (is_callable($linkConfig)) {
             return $linkConfig($source, $primaryKey, $displayValue);
         }
@@ -630,7 +630,7 @@ class AuditHelper extends Helper
      *
      * @return string HTML button
      */
-    public function restoreButton(string $source, int|string $primaryKey, array $options = []): string
+    public function restoreButton(string $source, string|int $primaryKey, array $options = []): string
     {
         $options += ['class' => 'btn btn-sm btn-success'];
 

--- a/tests/TestCase/Monitor/Channel/WebhookChannelTest.php
+++ b/tests/TestCase/Monitor/Channel/WebhookChannelTest.php
@@ -103,7 +103,7 @@ class WebhookChannelTest extends TestCase
              */
             public array $records = [];
 
-            public function log(mixed $level, string|Stringable $message, array $context = []): void
+            public function log(mixed $level, Stringable|string $message, array $context = []): void
             {
                 $this->records[] = ['level' => $level, 'message' => (string)$message];
             }


### PR DESCRIPTION
## Summary
- apply PHPCBF fixes for current php-collective/code-sniffer rules
- keep `composer cs-check` green after dependency updates

## Testing
- `composer update --no-interaction --no-progress`
- `composer cs-fix`
- `composer cs-check`