### PR TITLE
Add support for sebastian/diff 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=8.2",
         "cakephp/orm": "^5.3.0",
         "ext-json": "*",
-        "sebastian/diff": "^6.0 || ^7.0 || ^8.0"
+        "sebastian/diff": "^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
         "cakephp/cakephp": "^5.3.0",

--- a/src/Lib/DiffLib.php
+++ b/src/Lib/DiffLib.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AuditStash\Lib;
 
 use SebastianBergmann\Diff\Differ;
-use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
+use SebastianBergmann\Diff\Output\DiffOnlyOutputBuilder;
 
 /**
  * A library for generating HTML diffs between two strings.
@@ -538,7 +538,7 @@ class DiffLib
      */
     protected function getDiffArray(string $old, string $new): array
     {
-        $builder = new UnifiedDiffOutputBuilder();
+        $builder = new DiffOnlyOutputBuilder();
         $differ = new Differ($builder);
 
         return $differ->diffToArray($old, $new);


### PR DESCRIPTION
Adds `sebastian/diff ^9.0` to the allowed version range alongside the existing `^6.0 || ^7.0 || ^8.0`.

In diff 9.0 the `UnifiedDiffOutputBuilder` class was removed, so `DiffLib` now constructs the differ with `DiffOnlyOutputBuilder` instead. The output is unchanged: only `Differ::diffToArray()` is used, which ignores the output builder entirely. The `DiffOnlyOutputBuilder` class is present in diff 6, 7, 8, and 9, so the swap is compatible across the whole supported range.

Note: diff 9 requires PHP 8.4+ and is only resolvable for consumers on the phpunit 13 generation. This repository's own test matrix still exercises diff 8.x, so the `^9.0` branch is forward-compatible and was validated against the diff 9.0.0 API.