### PR TITLE
Fix PHPStan on CakePHP 5.4

### DIFF
--- a/src/View/Helper/AuditHelper.php
+++ b/src/View/Helper/AuditHelper.php
@@ -23,7 +23,7 @@ class AuditHelper extends Helper
  /**
   * Helpers to load
   *
-  * @var array
+  * @var array<int|string, array<string, mixed>|string>
   */
     protected array $helpers = ['Html'];
 


### PR DESCRIPTION
Updates helper annotations for CakePHP 5.4/PHPStan covariance checks.\n\nVerified locally with CakePHP 5.4.0-RC2:\n- composer stan\n- composer cs-check\n- composer test